### PR TITLE
优化CNN_pytorch.py

### DIFF
--- a/src/chap05_CNN/CNN_pytorch.py
+++ b/src/chap05_CNN/CNN_pytorch.py
@@ -89,13 +89,14 @@ class CNN(nn.Module):
         out1 = F.relu(out1)# 应用ReLU激活函数引入非线性
         out1 = self.dropout(out1)
         out2 = self.out2(out1)
-        output = F.softmax(out2, dim=1)  # 指定softmax维度
-        return output
+        return out2
 
 # 测试函数
 def test(cnn):
     global prediction  # 声明全局变量
     y_pre = cnn(test_x)  # 用模型预测测试数据
+     # 这里使用softmax获取概率分布
+    y_prob = F.softmax(y_pre, dim=1)
     _, pre_index = torch.max(y_pre, 1)  # 获取预测类别（最大概率的索引）
     pre_index = pre_index.view(-1)  # 调整张量形状
     prediction = pre_index.data.numpy()  # 转换为 numpy 数组


### PR DESCRIPTION
移除模型输出层的 softmax 激活函数：在CNN类的forward方法中，删除F.softmax(out2, dim=1)这一行，直接返回out2。
在测试函数中添加 softmax：只在需要概率输出的测试函数中使用softmax。