### PR TITLE
修改运行报错

### DIFF
--- a/src/chap07-seq2seq-and-attention/sequence_reversal_with_attention-exercise.py
+++ b/src/chap07-seq2seq-and-attention/sequence_reversal_with_attention-exercise.py
@@ -197,8 +197,13 @@ class mySeq2SeqModel(keras.Model):
         # 应用softmax获取注意力权重
         attn_weights = tf.nn.softmax(attn_scores, axis=-1)  # [batch_size, enc_seq_len]
         
+        attn_weights_expanded = tf.expand_dims(attn_weights, axis=1)  # [batch_size, 1, enc_seq_len]
+        
+        
         # 计算上下文向量
-        context = tf.matmul(attn_weights, enc_out)  # [batch_size, hidden]
+        context = tf.matmul(attn_weights_expanded, enc_out)  # [batch_size, 1, hidden]
+        
+        context = tf.squeeze(context, axis=1)  # [batch_size, hidden]
         
         # 4. 结合上下文向量和解码器输出
         dec_out_with_context = tf.concat([dec_out, context], axis=-1)  # [batch_size, hidden*2]


### PR DESCRIPTION
运行时报错：InvalidArgumentError: ConcatOp : Ranks of all input tensors should match: shape[0] = [32,128] vs. shape[1] = [32,32,128] [Op:ConcatV2] name: concat

原因：tf.concat 要求所有输入张量的rank（维度数）必须相同​​，而这里 dec_out 是 2D 张量，context 是 3D 张量，因此无法直接拼接。

修改后通过 tf.expand_dims 将 attn_weights 扩展为 [batch_size, 1, enc_seq_len]，确保矩阵乘法结果为 [batch_size, 1, hidden]，再压缩为 [batch_size, hidden]，与 dec_out 维度匹配。

部分结果（感觉怪怪的起码能运行）：
[True, False, True, True, False, True, False, False, True, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, True]
[('MLJXMAFGVTIJZVAZLJNR', 'RNJXZMEZFITVGFAMXJLM'), ('IPWSENWBRBTCWTLNQOVY', 'QIOQNLTWCTBRBWNESWPI'), ('HKBLXTETGNVOGBSLEAUH', 'PUHTLSBGOVNGTETXLBKH'), ('KDXQUPGSDFTBYRQLYCSS', 'CSIUYQAYMTFDSGPUQXDK'), ('FQOXCXWFBSXYJRGRPKWI', 'LWIPAGMOYXSBFWXCXOQF'), ('LAZGLXRZYWNAGPHDRQOS', 'SOQRDHPGMNWYZRXLGZAL'), ('GNGZMOACHVKYSVVRNIQW', 'WRINRVVSYKVHCAOMZGNG'), ('VGFLRZHFOCTRKKUBLWMF', 'CMPROGKGRTCOFHZRLFGV'), ('QHYCAQUZWSWZZBYHHFTO', 'OTFHHYBZZWSWZUQACYHQ'), ('AKAORTJYAXUVVYRAIYOT', 'TOYLARYVVUXAYJTROAKA'), ('DNIQRZJWBQNMWVGHJAQQ', 'QHAJHGVWMNQBWJZRQIND'), ('ZFKIKNPLBJRKSBFTBATJ', 'JYUOEFOSKRJBLPNKIKFZ'), ('YQVCARKRDNNZNUEKBGEP', 'XEGBCETNZNNDRKRACVQY'), ('NNQVDLWJJVTULBDRITVA', 'BVTXRDOLUTOJJWLDVQNN'), ('BBTHVUDKADQNQPPJJSVE', 'JINOMWPQXIDAKDUVHTBB'), ('IECPCJTBLZNRUAEKZYQE', 'TQEZKEAURNZLBTJCPCEI'), ('QWPQSSSDYZGZVQWUBKPE', 'UPMMULQVZGZYDSSSQPWQ'), ('IBYPXVNXYAJERQKZEXAC', 'EAIEZKQAEJAYXNVXPYBI'), ('BGJKSULYDYJJHSFEWNVU', 'UVNWEFSHJJYDYLUSKJGB'), ('BIGZSHFYFXMAMVJKNDHR', 'WHDNKJVAAMXFYFHSZGIB'), ('ISZHZBKNJGXSSBFMUKDE', 'JDWRZFBSSXGJNKBZHZSI'), ('TSTYMLZKGZTSFWVIEUNX', 'XNUEQVPFSTZGKZLMYTST'), ('FYHILQKZPEZDJLNAMXPQ', 'YYXMANLJDZEPZKQLIHYF'), ('FDUBXIZNQZHDBPIFHVFL', 'VZVFFWPBHQZQNZIXBUDF'), ('MQOIMVRZXPHWHREJAJVY', 'YVJAJERHWHPXZRVMIOQM'), ('RKMRAOBHOWQKITMIUWSI', 'ISWUIMTIKQWOHBOARMKR'), ('CGVOCVCOOQVIVFPXVCIY', 'UDZXFPBVIVQOOCVCOVGC'), ('JOUUCKXBMOELITOUEXPN', 'MHXQOOEILEOMBXKCUUOJ'), ('NAKNDIBTJMJTISFUAHKC', 'CKHAUFSITJMJTBIDNKAN'), ('UZWMWYDKFECJFNGFIGNR', 'UBUWFGZFJCEFKDYWMWZU'), ('GLEEQTZSSJZACBRGGRBC', 'ANAGGRBCAZJSSZTQEELG'), ('IDKFDMGVCUQUZEQZLDQH', 'VHQLZQEZUQUCVGMDFKDI')]