### PR TITLE
导入语句规范整理

### DIFF
--- a/src/chap05_CNN/CNN_pytorch.py
+++ b/src/chap05_CNN/CNN_pytorch.py
@@ -3,13 +3,13 @@
 
 # 导入必要的库
 import os
+import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from torch.autograd import Variable
 import torch.utils.data as Data
-import torchvision               # 包含常用的数据集和模型
-import torch.nn.functional as F  # 包含常用的函数式API，如ReLU, softmax等
-import numpy as np
-from torch.autograd import Variable # 导入自动微分变量，用于构建计算图和自动求导
+import torchvision 
 
 # 设置超参数
 learning_rate = 1e-4  #  学习率：控制参数更新步长


### PR DESCRIPTION
按照 PEP 8 规范，导入语句应按以下顺序分组：
标准库
第三方库
同一库的不同模块