### PR TITLE
优化 reversi_main.py

### DIFF
--- a/src/chap14_reinforcement_learning/reversi_main.py
+++ b/src/chap14_reinforcement_learning/reversi_main.py
@@ -108,7 +108,7 @@ for i_episode in range(max_epochs):
                 print("平局！")
             
             # 打印详细比分
-            white_score = total_tiles - black_score
+            white_score = env.board_size ** 2 - black_score  # 直接计算白棋得分（优化后）
             print(f"比分: 黑棋 {black_score} - 白棋 {white_score}")
             
             break  # 结束当前游戏，开始下一局


### PR DESCRIPTION
原代码通过 white_score = total_tiles - black_score 计算白棋得分，但 total_tiles 是之前定义的中间变量，增加了代码冗余。

直接使用 env.board_size ** 2 计算总格子数，避免引入中间变量 total_tiles
代码更简洁，减少变量定义，降低内存占用