### PR TITLE
增加manual_control.launch文件

### DIFF
--- a/src/Button_Control_Vehicle/carla_manual_control.launch
+++ b/src/Button_Control_Vehicle/carla_manual_control.launch
@@ -1,0 +1,10 @@
+<!-- -->
+<launch>
+  <arg name="role_name" default="ego_vehicle"/>
+
+  <node pkg="carla_manual_control" type="carla_manual_control.py" name="carla_manual_control_$(arg role_name)" output="screen">
+    <param name="role_name" value="$(arg role_name)"/>
+  </node>
+
+</launch>
+


### PR DESCRIPTION
1.首先，创建一个工作空间，ros_bridge_ws,再建一个src文件夹，将  git clone 下来的ros bridge 源码放里面
2.激活工作空间  cd ros_bridge_ws,         source devel/setup.bash
3.编译  我的是ros1  noetic  版本   catkin_make   (ros2  colcon build)
4.编译可能会出现缺少pygame模块   ，pip install pygame即可，缺少一些库比如tf  之类的  sudo apt install 即可
5.编译出现进度条并且达到100%即编译成功，开始roslaunch  carla_manual_control  maunal_control.launch
6.启动服务器carla   ./CarlaUE4.sh   ,若黑屏则./CarlaUE4.sh -quality-level=Low -RenderOffScreen
7.可通过按键控制车前进后退等
<img width="1920" height="1080" alt="2025-10-24 02-22-30 的屏幕截图" src="https://github.com/user-attachments/assets/0ef53910-fe61-4cd2-9451-6cc23130b3a8" />
