### PR TITLE
将w_lsq计算改为调用least_squares，是为复用其封装的输入检查、多求解器等功能，集中逻辑便于维护，支持扩展且增强鲁棒性，减少…

### DIFF
--- a/src/chap02_linear_regression/exercise-linear_regression.py
+++ b/src/chap02_linear_regression/exercise-linear_regression.py
@@ -212,7 +212,7 @@ def main(x_train, y_train, use_gradient_descent=False, basis_func=None):
     phi1 = basis_func(x_train)
     phi = np.concatenate([phi0, phi1], axis=1) # 将偏置项和特征矩阵拼接成完整的特征矩阵
     # 最小二乘法求解权重
-    w_lsq = np.dot(np.linalg.pinv(phi), y_train)
+    w_lsq = least_squares(phi, y_train)
 
     w_gd = None
     if use_gradient_descent:


### PR DESCRIPTION
…冗余与错误。