### PR TITLE
修复RNN状态初始化不匹配问题，保留一个状态张量

### DIFF
--- a/src/chap06_RNN/poem_generation_with_RNN-exercise.py
+++ b/src/chap06_RNN/poem_generation_with_RNN-exercise.py
@@ -419,9 +419,8 @@ def gen_sentence(model: myRNNModel, word2id: dict, id2word: dict, max_len: int =
     Returns:
         str: 生成的诗歌字符串（不包含开始和结束标记）
     """
-    # 初始化RNN隐藏状态（通常为两个状态变量，如LSTM的cell state和hidden state）
-    state = [tf.random.normal(shape=(1, 128), stddev=0.5),
-             tf.random.normal(shape=(1, 128), stddev=0.5)]
+    # 初始化RNN隐藏状态 - SimpleRNNCell只需要一个状态
+    state = tf.random.normal(shape=(1, 128), stddev=0.5)
 
     # 初始化当前token为开始标记
     cur_token = tf.constant([word2id[start_token]], dtype=tf.int32)


### PR DESCRIPTION
SimpleRNNCell 只需要一个隐藏状态，而原代码错误地初始化了两个状态变量,只需要保留一个状态张量，与模型定义中的 SimpleRNNCell 保持一致