### PR TITLE
data里面的模型权重不会再被误提交进去仓库

### DIFF
--- a/src/Car-Racing/.gitignore
+++ b/src/Car-Racing/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 data/train/
 data/test/
 
+data/
+Car-Racing-main/data/
+


### PR DESCRIPTION
解释:
data/：忽略当前目录下 data 这个文件夹
Car-Racing-main/data/：忽略旧目录下面的 data
之前Car-Racing-main和car_racing目录重复，现在已经改动到car_racing里面了