### PR TITLE
ROS封装感知模块，修正数据模块代码

### DIFF
--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_ros_demo/data_acquire.py
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_ros_demo/data_acquire.py
@@ -75,22 +75,22 @@ class DataAcquisitionNode(Node):
             self.finger_joint_pub.publish(joint_msg)
             
             # 2. 发布目标小球位置
+            target_body_id = self.sim.model.body('target').id  
             ball_msg = PointStamped()
             ball_msg.header.stamp = self.get_clock().now().to_msg()
             ball_msg.header.frame_id = 'sim_world'
-            ball_msg.point.x = self.sim.data.qpos[self.sim.target_joint_ids[0]]
-            ball_msg.point.y = self.sim.data.qpos[self.sim.target_joint_ids[1]]
-            ball_msg.point.z = self.sim.data.qpos[self.sim.target_joint_ids[2]]
+            ball_msg.point.x = self.sim.data.xpos[target_body_id][0]
+            ball_msg.point.y = self.sim.data.xpos[target_body_id][1]
+            ball_msg.point.z = self.sim.data.xpos[target_body_id][2]
             self.target_ball_pub.publish(ball_msg)
             
             # 3. 发布手指末端位置
             tip_msg = PointStamped()
             tip_msg.header.stamp = self.get_clock().now().to_msg()
             tip_msg.header.frame_id = 'sim_world'
-            if self.sim.data.xpos.shape[0] > 1:
-                tip_msg.point.x = self.sim.data.xpos[1][0]
-                tip_msg.point.y = self.sim.data.xpos[1][1]
-                tip_msg.point.z = self.sim.data.xpos[1][2]
+            tip_msg.point.x = self.sim.data.xpos[self.sim.finger_tip_body_id][0]
+            tip_msg.point.y = self.sim.data.xpos[self.sim.finger_tip_body_id][1]
+            tip_msg.point.z = self.sim.data.xpos[self.sim.finger_tip_body_id][2]
             self.finger_tip_pub.publish(tip_msg)
             
             # 4. 发布仿真时间

--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_ros_demo/perception_node.py
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_ros_demo/perception_node.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Float64MultiArray, Bool
+from geometry_msgs.msg import PointStamped
+from sensor_msgs.msg import JointState
+import numpy as np
+
+
+class PerceptionNode(Node):
+    def __init__(self):
+        super().__init__('perception_node')
+        
+        # 1. 初始化数据存储变量
+        self.finger_joint_angles = None  # 手指关节角度
+        self.finger_tip_pos = None       # 手指末端3D坐标 [x,y,z]
+        self.target_ball_pos = None      # 目标小球3D坐标 [x,y,z]
+        
+        # 2. 创建订阅者
+        self.joint_sub = self.create_subscription(
+            Float64MultiArray,
+            '/perception/finger_joint_angles',  # 关节角度话题（Float64MultiArray）
+            self.joint_angle_callback,
+            10
+        )
+        self.finger_tip_sub = self.create_subscription(
+            PointStamped,
+            '/perception/finger_tip_pos',       # 手指末端位置话题（PointStamped）
+            self.finger_tip_callback,
+            10
+        )
+        self.target_sub = self.create_subscription(
+            PointStamped,
+            '/perception/target_ball_pos',      # 目标小球位置话题（PointStamped）
+            self.target_callback,
+            10
+        )
+        
+        # 3. 创建发布者（输出处理结果）
+        self.result_pub = self.create_publisher(
+            Float64MultiArray,  # 格式：[距离, 命中标记(1/0)]
+            '/perception/result',
+            10
+        )
+        
+        # 4. 初始化定时器（周期性处理数据，10Hz）
+        self.timer = self.create_timer(0.1, self.process_data)
+        
+        self.get_logger().info("感知模块已启动，等待仿真数据...")
+
+    def joint_angle_callback(self, msg):
+        """接收手指关节角度数据"""
+        self.finger_joint_angles = msg.data
+        self.get_logger().debug(f"收到关节角度：{self.finger_joint_angles}")
+
+    def finger_tip_callback(self, msg):
+        """接收手指末端位置数据"""
+        self.finger_tip_pos = [msg.point.x, msg.point.y, msg.point.z]
+        self.get_logger().debug(f"收到手指末端位置：{self.finger_tip_pos}")
+
+    def target_callback(self, msg):
+        """接收目标小球位置数据"""
+        self.target_ball_pos = [msg.point.x, msg.point.y, msg.point.z]
+        self.get_logger().debug(f"收到目标小球位置：{self.target_ball_pos}")
+
+    def analyze_finger_pose(self):
+        """解析手指姿态（伸直/弯曲）"""
+        if self.finger_joint_angles is None:
+            return "未知"
+        
+        # 假设关节角度绝对值<0.1为伸直，否则为弯曲（可根据模型调整阈值）
+        avg_angle = np.mean(np.abs(self.finger_joint_angles))
+        return "伸直" if avg_angle < 0.1 else "弯曲"
+
+    def calculate_distance(self):
+        """计算手指末端与目标小球的欧式距离"""
+        if self.finger_tip_pos is None or self.target_ball_pos is None:
+            return None
+        
+        finger = np.array(self.finger_tip_pos)
+        target = np.array(self.target_ball_pos)
+        distance = np.linalg.norm(finger - target)
+        return round(distance, 4)
+
+    def process_data(self):
+        """周期性处理所有数据并发布结果"""
+        # 1. 检查数据完整性
+        if None in [self.finger_joint_angles, self.finger_tip_pos, self.target_ball_pos]:
+            self.get_logger().warn("等待完整仿真数据...")
+            return
+        
+        # 2. 解析手指姿态
+        finger_pose = self.analyze_finger_pose()
+        
+        # 3. 计算空间距离
+        distance = self.calculate_distance()
+        hit_mark = 1.0 if distance < 0.05 else 0.0  # 距离<5cm判定为命中
+        
+        # 4. 打印日志（可视化调试）
+        self.get_logger().info(f"=== 感知结果 ===")
+        self.get_logger().info(f"食指姿态：{finger_pose}")
+        self.get_logger().info(f"手指末端位置：{self.finger_tip_pos}")
+        self.get_logger().info(f"目标小球位置：{self.target_ball_pos}")
+        self.get_logger().info(f"空间距离：{distance} m | 命中标记：{int(hit_mark)}")
+        
+        # 5. 发布处理结果
+        result_msg = Float64MultiArray()
+        result_msg.data = [distance, hit_mark]
+        self.result_pub.publish(result_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    perception_node = PerceptionNode()
+    
+    try:
+        rclpy.spin(perception_node)
+    except KeyboardInterrupt:
+        perception_node.get_logger().info("感知模块已停止")
+    finally:
+        if rclpy.ok():  # 仅当上下文有效时销毁节点
+            perception_node.destroy_node()
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/setup.py
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/setup.py
@@ -35,6 +35,7 @@ setup(
             'mujoco_pub = mujoco_ros_demo.mujoco_publisher:main',
             'data_sub = mujoco_ros_demo.data_subscriber:main',
             'data_acquire = mujoco_ros_demo.data_acquire:main',
+            'perception_node = mujoco_ros_demo.perception_node:main',
         ],
     },
 )

--- a/src/HCL_interaction_task/mobl_arms_index_pointing/simulator.py
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/simulator.py
@@ -23,6 +23,9 @@ class Simulator:
             mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, "target_z")
         ]
 
+        self.finger_tip_body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "index3")  # 食指末端body名称
+        self.target_body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "target")  # 目标小球body名称
+
     def _init_viewer(self):
         """初始化viewer，适配不同版本的mujoco"""
         try:


### PR DESCRIPTION
一、创建感知模块文件：
1.订阅数据获取模块话题
```xml
/perception/finger_joint_angles（Float64MultiArray）：手指关节角度数组；
/perception/finger_tip_pos（PointStamped）：手指末端3D坐标；
/perception/target_ball_pos（PointStamped）：目标小球3D坐标）
```
2.发布话题
```xml
/perception/result（处理结果）：

[手指姿态]：关节角度的平均值阈值判断手指伸直/弯曲
[距离值]:欧式距离公式计算手指与目标的空间距离
[命中标记]:1 = 命中，0 = 未命中（距离<5cm判定为命中）
```
3.运行结果：
首先运行数据获取模块(data_acquire.py)，运行仿真发布话题
<img width="1917" height="989" alt="截图 2025-11-24 12-12-37" src="https://github.com/user-attachments/assets/f10b3efe-8068-41c5-a224-deb0589fcd9e" />

在终端运行感知模块(perception_node.py)，得到结果，通过“ros2 topic echo /perception/result”查看结果输出
<img width="667" height="618" alt="截图 2025-11-24 08-49-51" src="https://github.com/user-attachments/assets/50e11432-ab25-44ed-b903-b767d9e8b143" />
<img width="667" height="618" alt="截图 2025-11-24 08-49-51" src="https://github.com/user-attachments/assets/dda5be6b-6a74-4fb0-afd3-024afae83124" />

使用rqt可视化在plot和console查看数据绘图和日志输出
<img width="1917" height="989" alt="截图 2025-11-24 11-28-16" src="https://github.com/user-attachments/assets/49746038-c667-44ce-9999-ef0373f2bc16" />

二、修正数据获取模块代码
先前的小球位置订阅和手指末端位置订阅弄反了，现已修正，否则会出现感知模块订阅失败等问题。