### PR TITLE
用C++编写mujoco仿真运行节点

### DIFF
--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/CMakeLists.txt
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.8)
+project(mujoco_ros_demo)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+
+set(MUJOCO_INCLUDE_DIRS "/usr/local/mujoco-3.3.7/include")
+set(MUJOCO_LIBRARY_DIRS "/usr/local/mujoco-3.3.7/lib")
+
+# 包含MuJoCo头文件目录
+include_directories(${MUJOCO_INCLUDE_DIRS})
+# 链接MuJoCo库文件目录
+link_directories(${MUJOCO_LIBRARY_DIRS})
+
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+
+
+# mujoco_publisher_cpp（MuJoCo仿真发布节点）
+add_executable(mujoco_publisher_cpp mujoco_demo_cpp/mujoco_publisher.cpp)
+ament_target_dependencies(mujoco_publisher_cpp
+  rclcpp std_msgs Eigen3 ament_index_cpp)
+target_link_libraries(mujoco_publisher_cpp mujoco)  # 链接MuJoCo库
+
+
+# 安装C++节点
+install(TARGETS
+  mujoco_publisher_cpp
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# 安装config（模型文件）
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_demo_cpp/mujoco_publisher.cpp
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/mujoco_demo_cpp/mujoco_publisher.cpp
@@ -1,0 +1,65 @@
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
+#include "mujoco/mujoco.h"
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include <string>
+
+class MujocoPublisherCpp : public rclcpp::Node {
+public:
+    MujocoPublisherCpp() : Node("mujoco_publisher_cpp") {
+        // 读取现有config目录的模型（你的Python包已有的模型，无需重复放）
+        this->declare_parameter<std::string>("model_path", "config/humanoid.xml");
+        std::string model_rel_path = this->get_parameter("model_path").as_string();
+        
+        // 拼接绝对路径（自动找到你的mujoco_ros_demo包的share目录）
+        std::string pkg_share_dir = ament_index_cpp::get_package_share_directory("mujoco_ros_demo");
+        std::string model_path = pkg_share_dir + "/" + model_rel_path;
+        
+        // 加载MuJoCo模型
+        char error[1000];
+        model_ = mj_loadXML(model_path.c_str(), nullptr, error, 1000);
+        if (!model_) {
+            RCLCPP_FATAL(this->get_logger(), "Failed to load model: %s (path: %s)", error, model_path.c_str());
+            rclcpp::shutdown();
+        }
+        data_ = mj_makeData(model_);
+        
+        // 发布关节角度（话题名与Python节点一致，可替换或共存）
+        pub_ = this->create_publisher<std_msgs::msg::Float64MultiArray>("/mujoco/joint_angles", 10);
+        
+        // 50Hz定时器运行仿真
+        timer_ = this->create_wall_timer(
+            std::chrono::milliseconds(20),
+            std::bind(&MujocoPublisherCpp::sim_step, this));
+            
+        RCLCPP_INFO(this->get_logger(), "C++ MuJoCo Publisher started (model: %s)", model_path.c_str());
+    }
+
+    ~MujocoPublisherCpp() {
+        mj_deleteData(data_);
+        mj_deleteModel(model_);
+    }
+
+private:
+    void sim_step() {
+        mj_step(model_, data_);
+        auto msg = std_msgs::msg::Float64MultiArray();
+        int num_joints = std::min(6, model_->nq);  // 取前6个关节（适配你的模型）
+        for (int i = 0; i < num_joints; ++i) {
+            msg.data.push_back(data_->qpos[i]);
+        }
+        pub_->publish(msg);
+    }
+
+    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr pub_;
+    rclcpp::TimerBase::SharedPtr timer_;
+    mjModel* model_;
+    mjData* data_;
+};
+
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<MujocoPublisherCpp>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/setup.py
+++ b/src/HCL_interaction_task/mobl_arms_index_pointing/ros2_ws/src/mujoco_ros_demo/setup.py
@@ -38,4 +38,7 @@ setup(
             'perception_node = mujoco_ros_demo.perception_node:main',
         ],
     },
+    ament_cmake_options={
+        'install_extra_files': ['CMakeLists.txt'],
+    },
 )


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:    根据已有的mujoco_publisher.py的代码逻辑，编写C++的mujoco_publisher.cpp <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 创建mujoc_demo_cpp文件夹，与python节点处于统一目录
2. 添加CMakeLists.txt文件，增加setup.py配置
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. ros2 humble
2. mujoco
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
```bash
#1 运行命令
ros2 run mujoco_ros_demo mujoco_publisher_cpp
#2 打开新终端查看发布的数据
ros2 topic echo /mujoco/joint_angles
```
如图
<img width="369" height="853" alt="截图 2025-12-08 09-17-30" src="https://github.com/user-attachments/assets/f4c54848-5920-421b-83a8-c33017d60e7e" />

##注意
不需要进入虚拟环境
以及includepath的配置如图：
<img width="1137" height="480" alt="截图 2025-12-08 10-58-43" src="https://github.com/user-attachments/assets/61c42e0a-d50c-4faf-a9dc-d84e002c2ebe" />

