### PR TITLE
清除 CARLA 地图默认在车道上的静态车辆

### DIFF
--- a/src/self_driving_car_navigation/carla_environment.py
+++ b/src/self_driving_car_navigation/carla_environment.py
@@ -47,6 +47,13 @@ class CarlaEnvironment(gym.Env):
                 self.world = self.client.get_world()
                 self.blueprint_library = self.world.get_blueprint_library()
                 
+                # 关键修改：清除地图中所有默认静态车辆
+                actors = self.world.get_actors()
+                for actor in actors:
+                    if actor.type_id.startswith('vehicle.'):  # 筛选所有车辆类型
+                        actor.destroy()
+                        print(f"[清除默认车辆] 销毁静态车辆（ID: {actor.id}）")
+                
                 # 启用同步模式（关键优化：解决数据不同步问题）
                 self.settings = self.world.get_settings()
                 self.settings.synchronous_mode = True


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 
2. 
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等




修改的详细描述

该修改解决了 CARLA 仿真中地图默认生成在车道上的静止 NPC 车辆干扰仿真的问题，确保仿真场景中仅存在代码主动生成的主角车辆（特斯拉 Model3）。

经过了什么样的测试？
操作系统：Windows 11 （64 位）
CARLA 版本：0.9.11
Python 环境：Python 3.7.5（通过 VSCode 创建虚拟环境，使用venv管理依赖）

测试步骤与结果：

观察 CARLA 仿真场景，确认地图中无默认的静止在车道上的 NPC 车辆，仅生成了代码中定义的红色特斯拉 Model3 车辆。

运行结果前后的对比：

修改前的：

https://github.com/user-attachments/assets/00bef6fe-9654-47ec-a8fe-e2bb3bf9e91f



删除静止车辆后的：

https://github.com/user-attachments/assets/d53211d1-38e2-40d0-b8cc-b3f596c6a149
















