### PR TITLE
为wall2添加slide关节，使其可沿 Y 轴（左右）或 X 轴（前后）动态移动，保留wall1为固定障碍作为基础避障目标

### DIFF
--- a/src/embodied_robot/robot_walk/Robot_move_straight.xml
+++ b/src/embodied_robot/robot_walk/Robot_move_straight.xml
@@ -10,7 +10,7 @@
      limitations under the License.
 -->
 
-<mujoco model="Humanoid_With_Wall">
+<mujoco model="Humanoid_With_Dynamic_Wall">
   <option timestep="0.005"/>
 
   <visual>
@@ -27,9 +27,9 @@
     <material name="body" texture="body" texuniform="true" rgba="0.8 0.6 .4 1"/>
     <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
     <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
-    <!-- 障碍物材质（区分两个障碍） -->
-    <material name="wall_gray" rgba="0.6 0.6 0.6 1"/>
-    <material name="wall_blue" rgba="0.3 0.5 0.8 1"/>  <!-- 新增随机障碍材质 -->
+    <!-- 障碍物材质（区分固定/动态障碍） -->
+    <material name="wall_gray" rgba="0.6 0.6 0.6 1"/>    <!-- 固定障碍 -->
+    <material name="wall_blue" rgba="0.3 0.5 0.8 1"/>    <!-- 动态障碍 -->
   </asset>
 
   <default>
@@ -97,6 +97,10 @@
       <default class="elbow">
         <joint range="-100 50" stiffness="0"/>
       </default>
+      <!-- 动态障碍关节默认配置 -->
+      <default class="dynamic_wall_joint">
+        <joint type="slide" damping="10" stiffness="0" limited="true"/>
+      </default>
     </default>
   </default>
 
@@ -109,10 +113,15 @@
       <inertial pos="0 0 0" mass="100" diaginertia="1 1 1"/>
     </body>
 
-    <!-- 障碍2：固定占位位置（由Python脚本动态修改为随机位置） -->
-    <body name="wall2" pos="3.0 0.0 0.5">
-      <geom type="box" size="0.4 0.8 0.7" material="wall_blue" friction="1.0 0.1 0.1"/>
-      <inertial pos="0 0 0" mass="100" diaginertia="1 1 1"/>
+    <!-- 障碍2：动态障碍（沿Y轴左右移动，X轴固定3米） -->
+    <body name="wall2_base" pos="3.0 0.0 0.5">
+      <!-- 滑动关节：沿Y轴移动，范围-2~2米 -->
+      <joint name="wall2_slide_y" class="dynamic_wall_joint" axis="0 1 0" range="-2.0 2.0"/>
+      <!-- 动态障碍本体 -->
+      <body name="wall2" pos="0 0 0">
+        <geom type="box" size="0.4 0.8 0.7" material="wall_blue" friction="1.0 0.1 0.1"/>
+        <inertial pos="0 0 0" mass="50" diaginertia="1 1 1"/> <!-- 降低质量便于移动 -->
+      </body>
     </body>
 
     <light name="spotlight" mode="targetbodycom" target="torso" diffuse=".8 .8 .8" specular="0.3 0.3 0.3" pos="0 -6 4" cutoff="30"/>
@@ -233,6 +242,8 @@
     <motor name="shoulder1_left"  gear="20"  joint="shoulder1_left"/>
     <motor name="shoulder2_left"  gear="20"  joint="shoulder2_left"/>
     <motor name="elbow_left"      gear="40"  joint="elbow_left"/>
+    <!-- 动态障碍驱动电机 -->
+    <motor name="wall2_motor" gear="50" joint="wall2_slide_y" ctrlrange="-1 1"/>
   </actuator>
 
   <keyframe>

--- a/src/embodied_robot/robot_walk/move_straight.py
+++ b/src/embodied_robot/robot_walk/move_straight.py
@@ -2,41 +2,38 @@ import mujoco
 from mujoco import viewer
 import time
 import numpy as np
-import random  # 新增：随机转向控制
+import random
 
 
 def control_robot(model_path):
     """
-    控制DeepMind Humanoid模型：向前行走 → 检测所有障碍 → 随机转向避障最近障碍 → 回归路径 → 停止
-    适配多障碍物（固定+随机）场景
+    控制DeepMind Humanoid模型：在动态障碍环境中向前行走 → 实时检测动态障碍 → 随机转向避障 → 回归路径 → 停止
     """
     # 加载模型和数据
     model = mujoco.MjModel.from_xml_path(model_path)
     data = mujoco.MjData(model)
 
-    # -------------------------- 关键修复：动态生成随机障碍位置 --------------------------
-    # 找到wall2的body ID并修改其位置
-    wall2_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "wall2")
-    if wall2_id != -1:
-        # 随机生成wall2位置：x∈[2.5,4.0], y∈[-1.5,1.5], z固定0.5
-        random_x = 2.5 + random.random() * 1.5
-        random_y = -1.5 + random.random() * 3.0
-        # 修改模型中wall2的位置（mj_setGeomPos需要用data，或直接修改model.body_pos）
-        model.body_pos[wall2_id][0] = random_x
-        model.body_pos[wall2_id][1] = random_y
-        model.body_pos[wall2_id][2] = 0.5
-        print(f"已生成随机障碍wall2位置：x={random_x:.2f}, y={random_y:.2f}, z=0.5")
+    # -------------------------- 动态障碍初始化 --------------------------
+    # 获取动态障碍关节和电机ID
+    wall2_joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "wall2_slide_y")
+    wall2_motor_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "wall2_motor")
+    wall2_body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "wall2")
+
+    # 动态障碍参数
+    wall2_speed = 0.8  # 移动速度
+    wall2_amplitude = 1.8  # 移动幅度（Y轴-1.8~1.8米）
+    wall2_phase = random.uniform(0, 2 * np.pi)  # 随机初始相位
 
     # 打印电机数量（调试用）
     print(f"模型电机数量：{model.nu}，data.ctrl长度：{len(data.ctrl)}")
+    print(f"动态障碍配置：关节ID={wall2_joint_id}，电机ID={wall2_motor_id}，初始相位={wall2_phase:.2f}")
 
     # -------------------------- 兼容低版本MuJoCo的ID查询 --------------------------
-    # 关键修改：查询所有以"wall"开头的障碍物ID（支持wall1/wall2/更多）
     wall_ids = []
     wall_names = []
     for i in range(model.nbody):
         body_name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i)
-        if body_name and body_name.startswith("wall"):  # 匹配所有障碍体
+        if body_name and body_name.startswith("wall"):
             wall_ids.append(i)
             wall_names.append(body_name)
     torso_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "torso")
@@ -48,37 +45,38 @@ def control_robot(model_path):
         print("警告：未检测到任何障碍物！")
 
     # -------------------------- 核心参数配置 --------------------------
-    # 避障参数
+    # 避障参数（适配动态障碍）
     avoid_obstacle = False
-    obstacle_distance_threshold = 1.5  # 触发避障距离
+    obstacle_distance_threshold = 1.8  # 增大触发距离，预留反应时间
     obstacle_avoidance_time = 0
-    obstacle_avoidance_duration = 4.0  # 转向避障持续时间
-    turn_direction = 0  # 0:未选择, 1:右转, -1:左转（随机赋值）
-    return_to_path = False  # 是否进入回归路径阶段
+    obstacle_avoidance_duration = 4.5  # 延长避障时间，适配动态障碍
+    turn_direction = 0
+    return_to_path = False
     return_time = 0
-    return_duration = 3.0  # 回归路径持续时间
-    stop_walk = False  # 是否停止行走
-    closest_wall_id = -1  # 最近障碍物ID
+    return_duration = 3.5  # 延长回归时间，确保精准回归
+    stop_walk = False
+    closest_wall_id = -1
+    last_closest_wall_pos = np.zeros(2)  # 记录上一帧最近障碍位置，用于预判
 
-    # 步态控制参数
+    # 步态控制参数（降低速度，增强稳定）
     gait_period = 2.0
-    swing_gain = 0.9  # 进一步降低增益，提升多障碍场景稳定性
+    swing_gain = 0.85
     stance_gain = 0.8
-    forward_speed = 0.4  # 降低前进速度，预留更多避障反应时间
+    forward_speed = 0.35  # 进一步降低前进速度，适配动态环境
 
-    # 姿态稳定参数
+    # 姿态稳定参数（提高增益，防摔倒）
     torso_pitch_target = 0.0
     torso_roll_target = 0.0
-    torso_yaw_target = 0.0  # 偏航角目标（x轴正方向）
-    balance_kp = 90.0  # 提高平衡增益，防摔倒
-    balance_kd = 12.0
-    yaw_kp = 70.0  # 提高偏航回正增益，精准回归路径
+    torso_yaw_target = 0.0
+    balance_kp = 100.0
+    balance_kd = 15.0
+    yaw_kp = 80.0
 
     # 启动可视化器
     mujoco.set_mjcb_control(None)
     with viewer.launch_passive(model, data) as viewer_instance:
-        print("\nDeepMind Humanoid仿真启动！")
-        print("控制逻辑：向前行走 → 检测最近障碍 → 随机转向避障 → 回归路径 → 停止")
+        print("\nDeepMind Humanoid动态避障仿真启动！")
+        print("控制逻辑：向前行走 → 实时检测动态障碍 → 随机转向避障 → 回归路径 → 停止")
         start_time = time.time()
 
         try:
@@ -86,130 +84,144 @@ def control_robot(model_path):
                 if not viewer_instance.is_running():
                     break
 
-                # -------------------------- 1. 多障碍检测与状态切换 --------------------------
+                # -------------------------- 1. 驱动动态障碍移动 --------------------------
+                elapsed_time = time.time() - start_time
+                # 正弦曲线控制动态障碍Y轴往复移动
+                wall2_target_pos = wall2_amplitude * np.sin(wall2_speed * elapsed_time + wall2_phase)
+                # 控制动态障碍关节
+                if 0 <= wall2_motor_id < len(data.ctrl):
+                    data.ctrl[wall2_motor_id] = (wall2_target_pos - data.qpos[wall2_joint_id]) * 2.0  # PD控制
+
+                # -------------------------- 2. 实时检测动态障碍（最近障碍） --------------------------
                 distance_to_closest_wall = float('inf')
                 closest_wall_name = ""
+                closest_wall_pos = np.zeros(2)
 
-                # 计算到所有障碍物的距离，找到最近的那个
                 if wall_ids and torso_id != -1 and not stop_walk:
                     torso_pos = data.xpos[torso_id]
                     for idx, wall_id in enumerate(wall_ids):
                         wall_pos = data.xpos[wall_id]
                         distance = np.linalg.norm(torso_pos[:2] - wall_pos[:2])
+                        # 动态障碍预判：如果是wall2，额外计算未来0.5秒的位置
+                        if wall_names[idx] == "wall2":
+                            # 预估0.5秒后障碍位置
+                            future_wall2_pos = wall2_amplitude * np.sin(
+                                wall2_speed * (elapsed_time + 0.5) + wall2_phase)
+                            future_distance = np.linalg.norm(np.array([torso_pos[0], torso_pos[1]]) -
+                                                             np.array([wall_pos[0], future_wall2_pos]))
+                            distance = min(distance, future_distance)  # 取当前/未来距离最小值作为避障依据
+
                         if distance < distance_to_closest_wall:
                             distance_to_closest_wall = distance
                             closest_wall_id = wall_id
                             closest_wall_name = wall_names[idx]
+                            closest_wall_pos = wall_pos[:2]
 
-                # 状态切换逻辑（基于最近障碍物）
+                # -------------------------- 3. 动态避障状态切换 --------------------------
                 if closest_wall_id != -1 and torso_id != -1 and not stop_walk:
-                    # 1.1 触发避障（随机选择转向方向）
+                    # 触发避障（动态障碍提前触发）
                     if (distance_to_closest_wall < obstacle_distance_threshold and
                             not avoid_obstacle and not return_to_path):
                         avoid_obstacle = True
                         obstacle_avoidance_time = time.time()
-                        turn_direction = random.choice([-1, 1])  # 随机左转/右转
+                        turn_direction = random.choice([-1, 1])
                         dir_name = "左转" if turn_direction == -1 else "右转"
                         print(
-                            f"\n检测到最近障碍【{closest_wall_name}】！距离：{distance_to_closest_wall:.2f}米，开始{dir_name}避障...")
+                            f"\n检测到最近障碍【{closest_wall_name}】（动态）！距离：{distance_to_closest_wall:.2f}米，开始{dir_name}避障...")
 
-                    # 1.2 避障完成，进入回归路径阶段
+                    # 避障完成，进入回归路径
                     if avoid_obstacle and (time.time() - obstacle_avoidance_time) > obstacle_avoidance_duration:
                         avoid_obstacle = False
                         return_to_path = True
                         return_time = time.time()
                         print(f"{dir_name}避障完成，开始回归原前进方向...")
 
-                    # 1.3 回归路径完成，停止行走
+                    # 回归完成，停止行走
                     if return_to_path and (time.time() - return_time) > return_duration:
                         return_to_path = False
                         stop_walk = True
                         torso_pos = data.xpos[torso_id]
                         print(f"\n已回归原前进方向，停止行走！最终位置：x={torso_pos[0]:.2f}, y={torso_pos[1]:.2f}")
 
-                # -------------------------- 2. 步态周期计算 --------------------------
-                elapsed_time = time.time() - start_time
+                # -------------------------- 4. 步态周期计算 --------------------------
                 cycle = elapsed_time % gait_period
                 phase = cycle / gait_period
 
-                # -------------------------- 3. 关节控制核心逻辑 --------------------------
-                data.ctrl[:] = 0.0  # 重置控制指令
+                # -------------------------- 5. 关节控制核心逻辑 --------------------------
+                data.ctrl[:len(data.ctrl) - 1] = 0.0  # 重置机器人控制指令（保留动态障碍电机）
 
                 if stop_walk:
-                    # 4. 停止状态：所有关节归零，保持站立
+                    # 停止状态：所有关节归零，保持站立
                     continue
 
                 elif return_to_path:
-                    # 3. 回归路径模式：反向转向，回到x轴正方向
+                    # 回归路径模式：反向转向，回到x轴正方向
                     return_phase = (time.time() - return_time) / return_duration
-                    # 余弦减速回归，避免过冲（更平滑）
-                    return_speed = 1.2 * np.cos(return_phase * np.pi)
+                    return_speed = 1.3 * np.cos(return_phase * np.pi)
 
-                    # 3.1 躯干偏航角回正（关键：回到x轴正方向）
+                    # 躯干偏航角回正
                     if torso_id != -1:
                         torso_quat = data.xquat[torso_id]
-                        # 四元数转偏航角（yaw）- 修正计算方式，提升精度
                         yaw = np.arctan2(2 * (torso_quat[2] * torso_quat[3] - torso_quat[0] * torso_quat[1]),
                                          torso_quat[0] ** 2 - torso_quat[1] ** 2 - torso_quat[2] ** 2 + torso_quat[
                                              3] ** 2)
                         yaw_error = torso_yaw_target - yaw
 
-                        # 3.2 转向回正控制（多关节协同）
+                        # 转向回正控制
                         abdomen_z_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "abdomen_z")
                         hip_z_right_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "hip_z_right")
                         hip_z_left_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "hip_z_left")
 
-                        if 0 <= abdomen_z_act_id < len(data.ctrl):
+                        if 0 <= abdomen_z_act_id < len(data.ctrl) - 1:
                             data.ctrl[abdomen_z_act_id] = yaw_kp * yaw_error * return_speed
-                        if 0 <= hip_z_right_act_id < len(data.ctrl):
-                            data.ctrl[hip_z_right_act_id] = -yaw_error * return_speed * 0.6
-                        if 0 <= hip_z_left_act_id < len(data.ctrl):
-                            data.ctrl[hip_z_left_act_id] = yaw_error * return_speed * 0.6
+                        if 0 <= hip_z_right_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_z_right_act_id] = -yaw_error * return_speed * 0.7
+                        if 0 <= hip_z_left_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_z_left_act_id] = yaw_error * return_speed * 0.7
 
-                    # 3.3 保持基本站立姿态（增强平衡）
+                    # 保持基本站立姿态
                     for side in ["right", "left"]:
                         hip_y_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"hip_y_{side}")
                         knee_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"knee_{side}")
                         ankle_y_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"ankle_y_{side}")
-                        if 0 <= hip_y_act_id < len(data.ctrl):
-                            data.ctrl[hip_y_act_id] = -0.6
-                        if 0 <= knee_act_id < len(data.ctrl):
-                            data.ctrl[knee_act_id] = 0.9
-                        if 0 <= ankle_y_act_id < len(data.ctrl):
-                            data.ctrl[ankle_y_act_id] = 0.2
+                        if 0 <= hip_y_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_y_act_id] = -0.7
+                        if 0 <= knee_act_id < len(data.ctrl) - 1:
+                            data.ctrl[knee_act_id] = 1.0
+                        if 0 <= ankle_y_act_id < len(data.ctrl) - 1:
+                            data.ctrl[ankle_y_act_id] = 0.3
 
                 elif avoid_obstacle:
-                    # 2. 避障模式：转向绕开最近障碍
+                    # 避障模式：转向绕开最近障碍（适配动态障碍）
                     avoid_phase = (time.time() - obstacle_avoidance_time) / obstacle_avoidance_duration
-                    # 正弦曲线控制转向速度（先加速后减速，更自然）
-                    turn_speed = 1.3 * np.sin(avoid_phase * np.pi)
+                    turn_speed = 1.4 * np.sin(avoid_phase * np.pi)  # 增强转向力度
 
-                    # 2.1 转向控制（增强转向力度，确保绕开障碍）
+                    # 转向控制
                     hip_z_right_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "hip_z_right")
                     hip_z_left_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "hip_z_left")
                     abdomen_z_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "abdomen_z")
 
-                    if 0 <= hip_z_right_act_id < len(data.ctrl):
-                        data.ctrl[hip_z_right_act_id] = turn_direction * turn_speed * 0.9
-                    if 0 <= hip_z_left_act_id < len(data.ctrl):
-                        data.ctrl[hip_z_left_act_id] = -turn_direction * turn_speed * 0.9
-                    if 0 <= abdomen_z_act_id < len(data.ctrl):
-                        data.ctrl[abdomen_z_act_id] = turn_direction * turn_speed * 1.6
+                    if 0 <= hip_z_right_act_id < len(data.ctrl) - 1:
+                        data.ctrl[hip_z_right_act_id] = turn_direction * turn_speed * 1.0
+                    if 0 <= hip_z_left_act_id < len(data.ctrl) - 1:
+                        data.ctrl[hip_z_left_act_id] = -turn_direction * turn_speed * 1.0
+                    if 0 <= abdomen_z_act_id < len(data.ctrl) - 1:
+                        data.ctrl[abdomen_z_act_id] = turn_direction * turn_speed * 1.8
 
-                    # 2.2 保持平衡（防摔倒）
+                    # 保持平衡（增强动态环境稳定性）
                     for side in ["right", "left"]:
                         hip_y_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"hip_y_{side}")
                         knee_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"knee_{side}")
                         ankle_x_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"ankle_x_{side}")
-                        if 0 <= hip_y_act_id < len(data.ctrl):
-                            data.ctrl[hip_y_act_id] = -0.9
-                        if 0 <= knee_act_id < len(data.ctrl):
-                            data.ctrl[knee_act_id] = 1.1
-                        if 0 <= ankle_x_act_id < len(data.ctrl):
-                            data.ctrl[ankle_x_act_id] = 0.1  # 小幅脚踝调整，增强平衡
+                        if 0 <= hip_y_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_y_act_id] = -1.0
+                        if 0 <= knee_act_id < len(data.ctrl) - 1:
+                            data.ctrl[knee_act_id] = 1.2
+                        if 0 <= ankle_x_act_id < len(data.ctrl) - 1:
+                            data.ctrl[ankle_x_act_id] = 0.2
 
                 else:
-                    # 1. 正常向前行走模式（适配多障碍场景，更稳健）
+                    # 正常向前行走模式（适配动态障碍环境）
                     for side, sign in [("right", 1), ("left", -1)]:
                         swing_phase = (phase + 0.5 * sign) % 1.0
 
@@ -221,80 +233,85 @@ def control_robot(model_path):
                         ankle_y_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"ankle_y_{side}")
                         ankle_x_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"ankle_x_{side}")
 
-                        # 腿部关节控制（向前行走，降低幅度增强稳定）
-                        if 0 <= hip_x_act_id < len(data.ctrl):
+                        # 腿部关节控制（降低幅度，增强稳定）
+                        if 0 <= hip_x_act_id < len(data.ctrl) - 1:
                             data.ctrl[hip_x_act_id] = swing_gain * np.sin(2 * np.pi * swing_phase) * forward_speed
-                        if 0 <= hip_z_act_id < len(data.ctrl):
-                            data.ctrl[hip_z_act_id] = stance_gain * np.cos(2 * np.pi * swing_phase) * 0.25
-                        if 0 <= hip_y_act_id < len(data.ctrl):
-                            data.ctrl[hip_y_act_id] = -1.0 * np.sin(2 * np.pi * swing_phase) - 0.45
-                        if 0 <= knee_act_id < len(data.ctrl):
-                            data.ctrl[knee_act_id] = 1.3 * np.sin(2 * np.pi * swing_phase) + 0.75
-                        if 0 <= ankle_y_act_id < len(data.ctrl):
-                            data.ctrl[ankle_y_act_id] = 0.35 * np.cos(2 * np.pi * swing_phase)
-                        if 0 <= ankle_x_act_id < len(data.ctrl):
-                            data.ctrl[ankle_x_act_id] = 0.18 * np.sin(2 * np.pi * swing_phase)
+                        if 0 <= hip_z_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_z_act_id] = stance_gain * np.cos(2 * np.pi * swing_phase) * 0.2
+                        if 0 <= hip_y_act_id < len(data.ctrl) - 1:
+                            data.ctrl[hip_y_act_id] = -0.9 * np.sin(2 * np.pi * swing_phase) - 0.4
+                        if 0 <= knee_act_id < len(data.ctrl) - 1:
+                            data.ctrl[knee_act_id] = 1.2 * np.sin(2 * np.pi * swing_phase) + 0.7
+                        if 0 <= ankle_y_act_id < len(data.ctrl) - 1:
+                            data.ctrl[ankle_y_act_id] = 0.3 * np.cos(2 * np.pi * swing_phase)
+                        if 0 <= ankle_x_act_id < len(data.ctrl) - 1:
+                            data.ctrl[ankle_x_act_id] = 0.15 * np.sin(2 * np.pi * swing_phase)
 
-                    # 躯干稳定控制（防摔倒+保持前进方向）
+                    # 躯干稳定控制（增强动态环境平衡）
                     abdomen_x_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "abdomen_z")
                     abdomen_y_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "abdomen_y")
                     abdomen_z_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "abdomen_x")
 
                     if torso_id != -1:
                         torso_quat = data.xquat[torso_id]
-                        # 四元数转欧拉角（俯仰/侧翻）
                         pitch = 2 * (torso_quat[1] * torso_quat[3] - torso_quat[0] * torso_quat[2])
                         roll = 2 * (torso_quat[0] * torso_quat[1] + torso_quat[2] * torso_quat[3])
 
-                        # 平衡补偿（提高增益，增强稳定）
-                        if 0 <= abdomen_x_act_id < len(data.ctrl):
+                        # 平衡补偿（高增益）
+                        if 0 <= abdomen_x_act_id < len(data.ctrl) - 1:
                             data.ctrl[abdomen_x_act_id] = balance_kp * (torso_roll_target - roll) - balance_kd * \
                                                           data.qvel[abdomen_x_act_id]
-                        if 0 <= abdomen_y_act_id < len(data.ctrl):
+                        if 0 <= abdomen_y_act_id < len(data.ctrl) - 1:
                             data.ctrl[abdomen_y_act_id] = balance_kp * (torso_pitch_target - pitch) - balance_kd * \
                                                           data.qvel[abdomen_y_act_id]
-                        if 0 <= abdomen_z_act_id < len(data.ctrl):
-                            data.ctrl[abdomen_z_act_id] = 0.08 * np.sin(elapsed_time * 0.5)  # 减小扭腰幅度
+                        if 0 <= abdomen_z_act_id < len(data.ctrl) - 1:
+                            data.ctrl[abdomen_z_act_id] = 0.05 * np.sin(elapsed_time * 0.5)  # 减小扭腰
 
-                    # 手臂自然摆动（降低幅度，增强平衡）
+                    # 手臂自然摆动（降低幅度）
                     for side, sign in [("right", 1), ("left", -1)]:
                         shoulder1_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"shoulder1_{side}")
                         shoulder2_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"shoulder2_{side}")
                         elbow_act_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"elbow_{side}")
 
-                        shoulder1_cmd = 0.25 * np.sin(2 * np.pi * (phase + 0.5 * sign))
-                        shoulder2_cmd = 0.18 * np.cos(2 * np.pi * (phase + 0.5 * sign))
-                        elbow_cmd = -0.45 * np.sin(2 * np.pi * (phase + 0.5 * sign)) - 0.28
+                        shoulder1_cmd = 0.2 * np.sin(2 * np.pi * (phase + 0.5 * sign))
+                        shoulder2_cmd = 0.15 * np.cos(2 * np.pi * (phase + 0.5 * sign))
+                        elbow_cmd = -0.4 * np.sin(2 * np.pi * (phase + 0.5 * sign)) - 0.25
 
-                        if 0 <= shoulder1_act_id < len(data.ctrl):
+                        if 0 <= shoulder1_act_id < len(data.ctrl) - 1:
                             data.ctrl[shoulder1_act_id] = shoulder1_cmd
-                        if 0 <= shoulder2_act_id < len(data.ctrl):
+                        if 0 <= shoulder2_act_id < len(data.ctrl) - 1:
                             data.ctrl[shoulder2_act_id] = shoulder2_cmd
-                        if 0 <= elbow_act_id < len(data.ctrl):
+                        if 0 <= elbow_act_id < len(data.ctrl) - 1:
                             data.ctrl[elbow_act_id] = elbow_cmd
 
-                # -------------------------- 4. 仿真推进 --------------------------
+                # -------------------------- 6. 仿真推进 --------------------------
                 mujoco.mj_step(model, data)
                 viewer_instance.sync()
 
-                # 实时状态输出（适配多障碍）
+                # 实时状态输出（含动态障碍位置）
                 if torso_id != -1 and int(elapsed_time * 2) % 2 == 0:
                     if stop_walk:
                         status = "已停止"
                         dist_info = "—"
-                    elif return_to_path:
-                        status = "回归路径中"
-                        dist_info = f"{distance_to_closest_wall:.2f}m（最近障碍）"
-                    elif avoid_obstacle:
-                        status = f"避障中（{dir_name}）"
-                        dist_info = f"{distance_to_closest_wall:.2f}m（{closest_wall_name}）"
+                        wall2_pos_info = "—"
                     else:
-                        status = "正常行走"
-                        dist_info = f"{distance_to_closest_wall:.2f}m（最近障碍）"
+                        if return_to_path:
+                            status = "回归路径中"
+                        elif avoid_obstacle:
+                            status = f"避障中（{dir_name}）"
+                        else:
+                            status = "正常行走"
+                        dist_info = f"{distance_to_closest_wall:.2f}m（{closest_wall_name}）"
+                        # 动态障碍位置信息
+                        if wall2_body_id != -1:
+                            wall2_current_pos = data.xpos[wall2_body_id]
+                            wall2_pos_info = f"wall2(Y):{wall2_current_pos[1]:.2f}m"
+                        else:
+                            wall2_pos_info = "wall2:未知"
 
                     torso_pos = data.xpos[torso_id]
                     print(
-                        f"\r时间：{elapsed_time:.1f}s | 位置：x={torso_pos[0]:.2f}, y={torso_pos[1]:.2f} | 距离：{dist_info} | 状态：{status}",
+                        f"\r时间：{elapsed_time:.1f}s | 位置：x={torso_pos[0]:.2f}, y={torso_pos[1]:.2f} | 距离：{dist_info} | 动态障碍：{wall2_pos_info} | 状态：{status}",
                         end="")
 
                 time.sleep(model.opt.timestep * 2)


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
为wall2添加slide关节，使其可沿 Y 轴（左右）或 X 轴（前后）动态移动，保留wall1为固定障碍作为基础避障目标
驱动动态障碍沿 Y 轴正弦往复移动；
实时更新障碍位置检测，适配动态环境；
优化避障逻辑，增加动态障碍预判，避免碰撞；
增强机器人稳定性，适配动态环境的不确定性。
1. 
2. 
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
启动后，wall1固定在 x=3、y=0 位置，wall2沿 Y 轴 - 1.8~1.8 米正弦往复移动；
机器人沿 x 轴缓慢前进，实时检测最近障碍（含动态wall2的未来位置）；
距离 < 1.8 米时随机左转 / 右转避障，避障时间延长至 4.5 秒；
避障完成后回归 x 轴正方向（3.5 秒），最终停止行走；
控制台实时输出：时间、机器人位置、最近障碍距离、动态障碍 Y 轴位置、当前状态
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1995" height="604" alt="屏幕截图 2025-12-12 205349" src="https://github.com/user-attachments/assets/bfb046ff-6bf7-468e-8604-e51e9bb2c35e" />
