### PR TITLE
更新 main.py，增加了圆形轨迹的调用和圆形轨迹的MPC控制预测，能够运行

### DIFF
--- a/src/Unmanned_vehicle_control/main.py
+++ b/src/Unmanned_vehicle_control/main.py
@@ -1,10 +1,11 @@
 import time
 import threading
-from src.carla_simulator import CarlaSimulator
+import numpy as np
+from src.main_carla_simulator import CarlaSimulator
 from src.config import X_INIT_M, Y_INIT_M, N, dt, V_REF, LAPS
-from src.help_functions import get_eight_trajectory, get_ref_trajectory, update_reference_point
-from src.logger import Logger
-from src.mpc_controller import MpcController
+from src.main_help_functions import get_eight_trajectory, get_ref_trajectory, get_circle_trajectory, update_reference_point
+from src.main_logger import Logger
+from src.main_mpc_controller import MpcController
 
 def draw_trajectory_in_thread(carla, x_traj, y_traj, dt):
     while True:
@@ -13,13 +14,40 @@ def draw_trajectory_in_thread(carla, x_traj, y_traj, dt):
 
 carla = CarlaSimulator()
 carla.load_world('Town02_Opt')
-carla.spawn_ego_vehicle('vehicle.tesla.model3', x=X_INIT_M, y=Y_INIT_M, z=0.1)
+#carla.spawn_ego_vehicle('vehicle.tesla.model3', x=X_INIT_M, y=Y_INIT_M, z=0.1)
 carla.print_ego_vehicle_characteristics()
 carla.set_spectator(X_INIT_M, Y_INIT_M, z=50, pitch=-90)
 
-logger = Logger()
+#logger = Logger()
 
-x_traj, y_traj, v_ref, theta_traj = get_eight_trajectory(X_INIT_M, Y_INIT_M)
+#x_traj, y_traj, v_ref, theta_traj = get_eight_trajectory(X_INIT_M, Y_INIT_M) #“8”形状轨迹
+#current_idx = 0
+#laps = 0
+# 圆形轨迹参数：圆心（X_INIT_M, Y_INIT_M），半径20米，200个点
+x_traj, y_traj, v_ref, theta_traj = get_circle_trajectory(
+    x_center=X_INIT_M,
+    y_center=Y_INIT_M,
+    radius=20,
+    total_points=200
+)
+
+# 从圆形轨迹的第一个点生成车辆（确保车辆在轨迹上）
+init_x, init_y = x_traj[0], y_traj[0]
+# 获取初始角度（轨迹切线方向）
+init_yaw = np.rad2deg(theta_traj[0])
+carla.spawn_ego_vehicle(
+    'vehicle.tesla.model3',
+    x=init_x,
+    y=init_y,
+    z=0.1,
+    yaw=init_yaw  # 初始方向与轨迹一致
+)
+
+carla.print_ego_vehicle_characteristics()
+# 调整 spectator 位置以便更好观察圆形轨迹
+carla.set_spectator(X_INIT_M, Y_INIT_M, z=80, pitch=-90)  # 从圆心正上方俯视
+
+logger = Logger()
 current_idx = 0
 laps = 0
 


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. main.py 增加了圆形轨迹调用，并用MPC控制器在圆形轨迹预测控制，能够运行
2. 用“#”号注释掉“8”字形轨迹的函数，便可以运行圆形轨迹。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：windows
2. Python版本等python3.7.8
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等

https://github.com/user-attachments/assets/3ccf9508-5c59-48ed-8f11-11eff5bb1a1e





