### PR TITLE
新增 DQN vs DoubleDQN 评估对比脚本（compare_models）

### DIFF
--- a/src/Car-Racing/compare_models.py
+++ b/src/Car-Racing/compare_models.py
@@ -45,7 +45,7 @@ def evaluate_dqn(agent, num_episodes=5):  # Adjust num_episodes as needed
     from gymnasium.wrappers import GrayscaleObservation, ResizeObservation, FrameStackObservation, RecordVideo
     from dqn_model.DQN_model import SkipFrame  # Import SkipFrame from DQN_model
     env = gym.make("CarRacing-v3", continuous=False, render_mode="rgb_array")
-    env = RecordVideo(env, video_folder='C:\\Users\\25012\\Desktop\\rl-car-ddqn-main\\videos\\DQN')
+    env = RecordVideo(env, video_folder='videos\\DQN')
     env = SkipFrame(env, skip=4)
     env = GrayscaleObservation(env)
     env = ResizeObservation(env, (84, 84))


### PR DESCRIPTION
## 修改概述:
- 新增 `compare_models.py`：同时加载 `DQN.pt` 与 `DoubleDQN.pt`，在相同环境预处理与随机种子设置下分别评估，并输出对比指标。
- 评估过程使用 `RecordVideo` 录制视频，分别输出到 DQN/DoubleDQN 对应目录。

## 实现功能
- **模型加载与容错**
  - 优先加载已训练权重（`load_state=True`，`DQN.pt` / `DoubleDQN.pt`），失败时回退为按配置文件初始化（`configs/dqn.yaml` / `configs/double_dqn.yaml`）。
- **统一评估流程（可复现）**
  - 环境：`CarRacing-v3`，`continuous=False`，`render_mode="rgb_array"`。
  - 预处理：`SkipFrame(skip=4)` + 灰度 + Resize(84x84) + FrameStack(4)。
  - 评估时关闭探索：`agent.epsilon = 0`；每个 episode 使用固定 seed（`env.reset(seed=episode)`）。
- **输出指标与对比结果**
  - 逐局打印 score；最终输出 Avg Score、Success Rate（score > 0 的比例）与 Avg Steps，并打印两种模型对比结果。
- **视频输出**
  - DQN 评估视频输出到 `...\\videos\\DQN`。
  - DoubleDQN 评估视频输出到 `...\\videos\\DoubleDQN`（目录为代码中 `video_folder` 配置值）。

## 经过了什么样的测试?
- 视频录制验证：运行后检查 `video_folder` 目录下生成的评估视频文件；如启用 `RecordVideo`，需确保安装 `moviepy`（Gymnasium 录制依赖）。

## 运行效果
![动画5](https://github.com/user-attachments/assets/ffc847e9-d1a9-4d9b-a642-dd40efa19c8d)
ddqn-episode-1
![rl-video-DoubleDQN-episode-1](https://github.com/user-attachments/assets/275973d9-9027-4507-941a-f6b7d296b177)
dqn-episode-1
![rl-video-DQN-episode-1](https://github.com/user-attachments/assets/ebeb859c-a3e9-41de-8170-ec6a688dc9d0)
