### PR TITLE
规范 ROS 功能包的核心配置

### DIFF
--- a/src/self_driving_car_navigation/ros/CMakeLists.txt
+++ b/src/self_driving_car_navigation/ros/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.0.2)
+# 功能包名称（必须与package.xml中的name一致）
+project(mmap_test)
+
+# -------------------------- 适配Python3.7.5 --------------------------
+# 指定你的虚拟环境Python解释器路径（关键！）
+set(PYTHON_EXECUTABLE /home/pan-j-l/my_ros_project/venv_py37/bin/python3)
+# 系统Python3.7的头文件路径（Ubuntu20.04默认路径，一般无需修改）
+set(PYTHON_INCLUDE_DIR /usr/include/python3.7m)
+# 系统Python3.7的库文件路径（Ubuntu20.04默认路径，一般无需修改）
+set(PYTHON_LIBRARY /usr/lib/x86_64-linux-gnu/libpython3.7m.so)
+
+# -------------------------- 查找ROS依赖包 --------------------------
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+  sensor_msgs
+  cv_bridge
+)
+
+# -------------------------- 声明Catkin包 --------------------------
+catkin_package(
+  # 声明该包依赖的其他ROS包，供其他包引用
+  CATKIN_DEPENDS rospy std_msgs sensor_msgs cv_bridge
+)
+
+# -------------------------- 安装Python脚本 --------------------------
+# 将scripts目录下的Python脚本安装到ROS的devel目录，实现全局调用
+catkin_install_python(PROGRAMS
+  scripts/ros_test_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# -------------------------- 包含目录 --------------------------
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/src/self_driving_car_navigation/ros/package.xml
+++ b/src/self_driving_car_navigation/ros/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <!-- 功能包基本信息 -->
+  <name>mmap_test</name>
+  <version>0.0.1</version>
+  <description>ROS Noetic功能包：集成感知模块与决策模块的测试节点</description>
+  <!-- 修正：使用合法的QQ邮箱 -->
+  <maintainer email="3541417288@qq.com">pan-j-l</maintainer>
+  <license>MIT</license>
+
+  <!-- 编译工具依赖 -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- ROS运行时依赖 -->
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>cv_bridge</exec_depend>
+
+  <!-- 导出编译类型 -->
+  <export>
+    <build_type>catkin</build_type>
+  </export>
+</package>


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 
2. 
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等





修改的详细描述
1. 完善`mmap_test`功能包的`package.xml`配置解决了原配置中邮箱格式无效的编译错误。
2. 优化`CMakeLists.txt`编译规则：适配Python3.7.5虚拟环境的解释器、头文件及库文件路径。


## 经过了什么样的测试?
1. 操作系统：Ubuntu 20.04 LTS（运行在VMware Workstation虚拟机环境）。
2. Python版本：3.7.5（基于`venv_py37`虚拟环境运行，已安装opencv-python==4.5.5.62、torch==1.13.1等库）。
3. ROS版本：Noetic 

运行结果：
<img width="2199" height="1697" alt="13" src="https://github.com/user-attachments/assets/5092cfaf-3261-4f60-81a0-e93ba9792b63" />










