### PR TITLE
重构ROS节点为类式封装，新增模拟数据版perception_decision_node节点

### DIFF
--- a/src/self_driving_car_navigation/ros/perception_decision_node.py
+++ b/src/self_driving_car_navigation/ros/perception_decision_node.py
@@ -1,0 +1,106 @@
+#!/home/pan-j-l/my_ros_project/venv_py37/bin/python3
+# 适配你的虚拟环境Python解释器路径（关键！避免环境依赖问题）
+import rospy
+import torch
+from geometry_msgs.msg import Twist
+from sensor_msgs.msg import Image, Imu, LaserScan
+# 导入自定义感知/决策模块（路径适配你的scripts/models目录）
+from models.perception_module import PerceptionModule
+from models.decision_module import DecisionModule
+
+class PerceptionDecisionNode:
+    def __init__(self):
+        # 节点初始化
+        rospy.init_node('perception_decision_node', anonymous=True)
+        self.node_name = rospy.get_name()
+        rospy.loginfo(f"[{self.node_name}] 节点初始化成功！")
+
+        # 加载参数（带默认值，可通过命令行/launch动态修改）
+        self.image_shape = rospy.get_param('~image_shape', (3, 128, 128))
+        self.feature_dim = rospy.get_param('~feature_dim', 128)
+        self.cmd_dim = rospy.get_param('~cmd_dim', 2)
+        self.timer_freq = rospy.get_param('~timer_freq', 10.0)
+        
+        # 打印加载的参数（日志格式和你预期的一致）
+        rospy.loginfo(f"[{self.node_name}] 加载参数完成：")
+        rospy.loginfo(f"  - 图像形状：{self.image_shape}")
+        rospy.loginfo(f"  - 特征维度：{self.feature_dim}")
+        rospy.loginfo(f"  - 指令维度：{self.cmd_dim}")
+        rospy.loginfo(f"  - 定时器频率：{self.timer_freq}Hz")
+
+        # 初始化感知/决策模块
+        try:
+            self.perception = PerceptionModule(
+                image_input_shape=self.image_shape,
+                output_feature_dim=self.feature_dim
+            )
+            self.decision = DecisionModule(
+                input_feature_dim=self.feature_dim,
+                output_cmd_dim=self.cmd_dim
+            )
+            rospy.loginfo(f"[{self.node_name}] 感知/决策模块初始化成功！")
+        except Exception as e:
+            rospy.logfatal(f"[{self.node_name}] 模块初始化失败：{str(e)}")
+            exit(1)  # 模块初始化失败直接退出
+
+        # 初始化控制指令发布者（发布到/cmd_vel话题）
+        self.cmd_pub = rospy.Publisher('/cmd_vel', Twist, queue_size=10)
+        rospy.loginfo(f"[{self.node_name}] 发布者初始化成功：/cmd_vel话题")
+
+        # 初始化定时器（按设定频率执行数据处理逻辑）
+        self.timer = rospy.Timer(
+            rospy.Duration(1.0 / self.timer_freq),
+            self.timer_callback
+        )
+        rospy.loginfo(f"[{self.node_name}] 定时器初始化成功：{self.timer_freq}Hz")
+        rospy.loginfo(f"[{self.node_name}] 节点开始运行（按Ctrl+C退出）...")
+
+    def timer_callback(self, event):
+        """定时器回调：核心逻辑（模拟数据→感知→决策→发布指令）"""
+        # ========== 跳过传感器等待：直接生成模拟数据 ==========
+        # 模拟IMU数据（1个batch，6维：线加速度x/y/z + 角速度x/y/z）
+        self.imu_data = torch.randn(1, 6)
+        # 模拟图像数据（1个batch，对应image_shape参数）
+        self.image_data = torch.randn(1, *self.image_shape)
+        # 模拟激光雷达数据（1个batch，360个扫描点）
+        self.lidar_data = torch.randn(1, 360)
+
+        try:
+            # 1. 感知模块：融合多传感器数据生成特征
+            fused_feature = self.perception.process(
+                self.imu_data,
+                self.image_data,
+                self.lidar_data
+            )
+
+            # 2. 决策模块：根据融合特征生成控制指令
+            control_cmd = self.decision.get_control_cmd(fused_feature)
+
+            # 3. 封装并发布ROS控制指令（Twist消息）
+            twist_msg = Twist()
+            twist_msg.linear.x = control_cmd['linear_x']  # 线速度x
+            twist_msg.angular.z = control_cmd['angular_z'] # 角速度z
+            self.cmd_pub.publish(twist_msg)
+
+            # 4. 打印日志（格式和你预期的完全一致）
+            rospy.loginfo(
+                f"[{self.node_name}] 生成控制指令：线速度x={control_cmd['linear_x']:.2f}m/s，"
+                f"角速度z={control_cmd['angular_z']:.2f}rad/s"
+            )
+
+        except Exception as e:
+            # 异常捕获：避免单个错误导致节点崩溃
+            rospy.logerr(f"[{self.node_name}] 指令生成失败：{str(e)}")
+
+if __name__ == '__main__':
+    try:
+        # 创建节点实例并运行
+        node = PerceptionDecisionNode()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        # 捕获Ctrl+C中断，友好退出
+        rospy.loginfo(f"[{rospy.get_name()}] 节点被中断，正常退出！")
+    except Exception as e:
+        # 捕获其他致命错误
+        rospy.logfatal(f"节点启动失败：{str(e)}")
+        exit(1)


### PR DESCRIPTION

## 修改的详细描述
1. 重构ROS节点为类式封装：新增`perception_decision_node.py`文件，将原有函数式`ros_test_node.py`重构为面向对象的`PerceptionDecisionNode`类，
2. 新增模拟数据逻辑：跳过真实传感器依赖，在定时器回调中生成模拟IMU（6维）、图像（3×128×128）、激光雷达（360点）数据，验证感知/决策模块核心逻辑；
3. 规范参数管理：从ROS参数服务器加载配置（特征维度、定时器频率等），支持命令行/launch文件动态传参，替代硬编码参数；
4. 统一日志输出格式：日志中增加节点名前缀，输出加载的参数信息、控制指令等，匹配预期的可视化输出效果；
5. 异常捕获优化：新增模块初始化、数据处理阶段的异常捕获逻辑，避免单个错误导致节点崩溃，提升鲁棒性；
6. 完善ROS话题交互：初始化`/cmd_vel`话题发布者，将决策模块生成的控制指令封装为`Twist`消息并发布，完成端到端逻辑验证。

## 经过了什么样的测试?
1. 操作系统：Ubuntu 20.04 LTS（VMware Workstation Pro 虚拟机）；
2. Python版本：3.7.5（自定义虚拟环境`venv_py37`，位于`/home/pan-j-l/my_ros_project/`）；
3. ROS版本：ROS Noetic （适配Ubuntu20.04）；
4. 测试步骤：
   - 步骤1：启动ROS核心服务`roscore`，确认端口11311无占用；
   - 步骤2：进入ROS工作空间`catkin_ws`，执行`source devel/setup.bash`刷新环境变量；
   - 步骤3：运行节点`rosrun mmap_test perception_decision_node.py`，检查节点初始化日志；
   - 步骤4：通过`rostopic echo /cmd_vel`验证控制指令是否正常发布；
   - 步骤5：动态传参测试（`rosrun mmap_test perception_decision_node.py _feature_dim:=256 _timer_hz:=5`），验证参数加载逻辑；


运行结果：

<img width="2291" height="1786" alt="14" src="https://github.com/user-attachments/assets/ac3ec248-00de-4d4d-8f6d-f1827550a1cb" />


