### PR TITLE
提交.launch文件，实现ROS节点一键启动

### DIFF
--- a/src/self_driving_car_navigation/ros/launch/perception_decision.launch
+++ b/src/self_driving_car_navigation/ros/launch/perception_decision.launch
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+    <!-- 全局参数配置 -->
+    <param name="/perception_decision_node/image_shape" value="[3, 128, 128]" />
+    <param name="/perception_decision_node/feature_dim" value="128" />
+    <param name="/perception_decision_node/cmd_dim" value="2" />
+    <param name="/perception_decision_node/timer_freq" value="10" />
+
+    <!-- 启动节点：移除shell属性，指定系统Python + 虚拟环境依赖 -->
+    <node 
+        name="perception_decision_node"
+        pkg="mmap_test"
+        type="perception_decision_node.py"
+        output="screen"
+        respawn="false">
+        
+        <!-- 关键：让Python同时加载系统ROS包 + 虚拟环境的torch等包 -->
+        <env name="PYTHONPATH" value="/home/pan-j-l/my_ros_project/venv_py37/lib/python3.7/site-packages:/opt/ros/noetic/lib/python3/dist-packages:$PYTHONPATH" />
+        <!-- 指定ROS的Python解释器（避免虚拟环境无rospy） -->
+        <env name="ROS_PYTHON_VERSION" value="3" />
+    </node>
+
+</launch>

--- a/src/self_driving_car_navigation/ros/perception_decision_node.py
+++ b/src/self_driving_car_navigation/ros/perception_decision_node.py
@@ -15,11 +15,14 @@ class PerceptionDecisionNode:
         self.node_name = rospy.get_name()
         rospy.loginfo(f"[{self.node_name}] 节点初始化成功！")
 
-        # 加载参数（带默认值，可通过命令行/launch动态修改）
-        self.image_shape = rospy.get_param('~image_shape', (3, 128, 128))
-        self.feature_dim = rospy.get_param('~feature_dim', 128)
-        self.cmd_dim = rospy.get_param('~cmd_dim', 2)
-        self.timer_freq = rospy.get_param('~timer_freq', 10.0)
+     
+        image_shape_str = rospy.get_param('~image_shape', "[3, 128, 128]")  # 读字符串
+        self.image_shape = tuple(map(int, image_shape_str.strip('[]').replace(' ', '').split(',')))  # 核心转换
+
+        # 2. 处理数值型参数（字符串→int/float）
+        self.feature_dim = int(rospy.get_param('~feature_dim', 128))  # 转整数
+        self.cmd_dim = int(rospy.get_param('~cmd_dim', 2))            # 转整数
+        self.timer_freq = float(rospy.get_param('~timer_freq', 10.0)) # 转浮点数
         
         # 打印加载的参数（日志格式和你预期的一致）
         rospy.loginfo(f"[{self.node_name}] 加载参数完成：")


### PR DESCRIPTION
## 修改的详细描述
1. 新增并完善launch文件：配置全局参数（image_shape/feature_dim等）+ 虚拟环境兼容环境变量，确保参数加载与依赖共存； launch文件自动启动roscore，无需手动开终端执行roscore。

2. 优化perception_decision_node.py节点脚本：修复参数类型转换问题：将ROS参数服务器读取的字符串型参数（如image_shape="[3,128,128]"）解析为元组/数值类型，解决"can't multiply sequence by non-int of type 'str'"报错。

3. 实现ROS节点一键启动。

## 经过了什么样的测试?
1. 操作系统：Ubuntu 20.04（VMware Workstation Pro 虚拟机）；
2. Python版本：3.7.5（自定义虚拟环境venv_py37，路径：/home/pan-j-l/my_ros_project/venv_py37/）；
3. ROS版本：ROS Noetic Ninjemys（适配Ubuntu20.04）；
4. 测试结果：单条roslaunch命令完成一键启动，无任何报错。



运行结果：
<img width="2213" height="1256" alt="15" src="https://github.com/user-attachments/assets/f307c49e-1f3a-475a-811b-1e7cb1e47e43" />
<img width="2223" height="1379" alt="16" src="https://github.com/user-attachments/assets/ed9098a3-0d69-4fc6-a072-da07a22bfa07" />




