### PR TITLE
增加launch文件，建图后可一键保存

### DIFF
--- a/src/carla_slam_gmapping/save_map.launch
+++ b/src/carla_slam_gmapping/save_map.launch
@@ -1,0 +1,32 @@
+<launch>
+  <!-- =====================================================================
+       地图保存工具
+       功能：将SLAM建立的地图保存到maps文件夹
+       
+       使用方法：
+       1. 先运行SLAM建图launch文件（gmapping或hector_slam）
+       2. 手动控制车辆完成建图
+       3. 在新终端运行此launch文件保存地图
+       
+       roslaunch carla_spawn_objects save_map.launch map_name:=carla_town01_map
+       ===================================================================== -->
+
+  <!-- 地图文件名（不包含扩展名） -->
+  <arg name="map_name" default="carla_map"/>
+  
+  <!-- 地图保存路径 -->
+  <arg name="map_path" default="$(find carla_spawn_objects)/maps"/>
+
+  <!-- ====================== 地图保存节点 ====================== -->
+  <!-- 订阅/map话题，保存为.pgm和.yaml文件 -->
+  <node 
+    pkg="map_server" 
+    type="map_saver" 
+    name="map_saver" 
+    output="screen"
+    args="-f $(arg map_path)/$(arg map_name)"
+  >
+    <remap from="map" to="/map"/>
+  </node>
+
+</launch>


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:    增加launch文件，建图后可一键保存
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
 地图保存工具
 功能：将SLAM建立的地图保存到maps文件夹
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统  ubuntu 20.04
2. Python版本等  ros1  python=3.8
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1892" height="1080" alt="960fa1ef4107c6042a488af722cc78da" src="https://github.com/user-attachments/assets/0132fcbd-0ea5-4933-bfa7-81f4216d811a" />
