### PR TITLE
修复FPS显示位置被覆盖问题

### DIFF
--- a/src/Unmanned_car_perceive/main.py
+++ b/src/Unmanned_car_perceive/main.py
@@ -256,7 +256,7 @@ class Main():
                 # 🆕 显示摄像头图像
                 self.drawer.display_camera()
 
-                # 🆕 显示帧率
+                # 🆕 显示帧率 - 确保这个调用在最后，显示在最上层
                 self.drawer.display_fps(self.fps)
 
                 # 更新观察者视角跟随车辆
@@ -264,7 +264,6 @@ class Main():
 
         except Exception as e:
             print(f"⚠️  更新车辆状态失败: {e}")
-
     def update_spectator(self):
         """更新观察者视角"""
         try:


### PR DESCRIPTION
在原来的代码中有时帧率显示会被覆盖，调整了FPS显示的位置，确保它在摄像头图像的上方，并且不会被遮挡
同时，给FPS文本添加一个背景框，以提高可读性。
<img width="1936" height="1224" alt="屏幕截图 2025-12-27 173434" src="https://github.com/user-attachments/assets/e32cfd59-bd42-4354-985a-5841436b399f" />
