### PR TITLE
让脚本的配置集中化， 鲁棒性大幅提升，. 逻辑简化 + 易扩展，可读性优化

### DIFF
--- a/src/robotic_arm_gripping/Specialized_gripper.py
+++ b/src/robotic_arm_gripping/Specialized_gripper.py
@@ -3,54 +3,127 @@ import mujoco.viewer
 import time
 import os
 
-MODEL_PATH = "arm_model.xml"
+# ===================== 配置项（集中管理，一键修改） =====================
+MODEL_PATH = "arm_model.xml"  # 模型文件路径（建议替换为绝对路径）
+# 相机配置（聚焦夹爪，看清细节）
+CAMERA_CONFIG = {
+    "distance": 1.0,
+    "azimuth": 60,
+    "elevation": -10,
+    "lookat": [0.4, 0, 0.4]
+}
+STEP_DELAY = 0.005  # 仿真步延迟（控制夹爪运动速度）
+# 夹爪运动阶段配置（易扩展，可调整各阶段时长）
+GRIPPER_PHASES = {
+    "open": {"steps": 400, "left_torque": -1.0, "right_torque": -1.0, "desc": "张开夹爪"},
+    "close": {"steps": 400, "left_torque": 1.0, "right_torque": 1.0, "desc": "闭合夹爪"},
+    "hold": {"steps": 200, "left_torque": 1.0, "right_torque": 1.0, "desc": "保持闭合"}
+}
 
-def main():
-    # 加载模型
-    if not os.path.exists(MODEL_PATH):
-        print(f"❌ 模型文件不存在：{MODEL_PATH}")
+
+# ===================== 工具函数（解耦核心逻辑，提升鲁棒性） =====================
+def load_model(model_path):
+    """
+    加载MuJoCo模型，包含完整的错误处理
+    :param model_path: 模型文件路径
+    :return: (model, data) 或 None（加载失败）
+    """
+    # 检查文件是否存在
+    if not os.path.exists(model_path):
+        print(f"❌ 错误：模型文件不存在 → {model_path}")
+        print("  建议替换为绝对路径，例如：C:/Users/XXX/arm_model.xml")
+        return None
+
+    # 捕获模型加载异常
+    try:
+        model = mujoco.MjModel.from_xml_path(model_path)
+        data = mujoco.MjData(model)
+        print(f"✅ 模型加载成功 → {model_path}")
+        return model, data
+    except Exception as e:
+        print(f"❌ 模型加载失败 → {e}")
+        return None
+
+
+def init_viewer(model, data, camera_config):
+    """
+    初始化可视化窗口（兼容所有MuJoCo版本，避免类型注解报错）
+    :param model: MuJoCo模型对象
+    :param data: MuJoCo数据对象
+    :param camera_config: 相机配置字典
+    :return: 可视化窗口对象
+    """
+    # 兼容新旧版本的viewer启动方式
+    try:
+        viewer = mujoco.viewer.launch(model, data)
+    except AttributeError:
+        viewer = mujoco.viewer.launch_passive(model, data)
+
+    # 配置相机参数，聚焦夹爪
+    viewer.cam.distance = camera_config["distance"]
+    viewer.cam.azimuth = camera_config["azimuth"]
+    viewer.cam.elevation = camera_config["elevation"]
+    viewer.cam.lookat = camera_config["lookat"]
+    return viewer
+
+
+# ===================== 核心逻辑（夹爪控制） =====================
+def gripper_control_test():
+    """夹爪单独控制测试主函数"""
+    # 1. 加载模型
+    model_data = load_model(MODEL_PATH)
+    if not model_data:
         return
-    model = mujoco.MjModel.from_xml_path(MODEL_PATH)
-    data = mujoco.MjData(model)
+    model, data = model_data
 
-    # 只关注夹爪执行器
-    left_act = model.actuator("left").id
-    right_act = model.actuator("right").id
+    # 2. 获取夹爪执行器ID（增加异常处理）
+    try:
+        left_act_id = model.actuator("left").id
+        right_act_id = model.actuator("right").id
+    except Exception as e:
+        print(f"❌ 获取夹爪执行器失败 → {e}")
+        print("  请检查模型中actuator的name是否为'left'/'right'")
+        return
 
-    # 可视化
-    viewer = mujoco.viewer.launch(model, data)
-    viewer.cam.distance = 1.0  # 拉近相机，看清夹爪
-    viewer.cam.azimuth = 60
-    viewer.cam.elevation = -10
-    viewer.cam.lookat = [0.4, 0, 0.4]
+    # 3. 初始化可视化窗口
+    viewer = init_viewer(model, data, CAMERA_CONFIG)
+    print("\n===== 夹爪单独控制测试 =====")
+    print("操作说明：按ESC键退出测试")
+    print("运动流程：", " → ".join([phase["desc"] for phase in GRIPPER_PHASES.values()]), "→ 循环\n")
 
-    print("===== 夹爪单独控制测试 =====")
-    print("夹爪会循环：张开 → 闭合 → 保持 → 张开 | ESC退出")
+    # 4. 阶段管理（简化循环逻辑，易扩展）
+    phase_list = list(GRIPPER_PHASES.values())
+    current_phase_idx = 0  # 当前阶段索引
+    phase_step = 0  # 当前阶段内的步数
 
-    step = 0
     while viewer.is_running():
-        # 阶段1：0-400步 → 张开夹爪
-        if step < 400:
-            data.ctrl[left_act] = -1.0
-            data.ctrl[right_act] = -1.0
-        # 阶段2：400-800步 → 闭合夹爪
-        elif step < 800:
-            data.ctrl[left_act] = 1.0
-            data.ctrl[right_act] = 1.0
-        # 阶段3：800-1000步 → 保持闭合
-        elif step < 1000:
-            data.ctrl[left_act] = 1.0
-            data.ctrl[right_act] = 1.0
-        # 阶段4：重置步数，循环
-        else:
-            step = 0
+        # 获取当前阶段配置
+        current_phase = phase_list[current_phase_idx]
 
+        # 打印阶段提示（仅在阶段开始时打印一次）
+        if phase_step == 0:
+            print(f"🔄 {current_phase['desc']}（剩余步数：{current_phase['steps']}）")
+
+        # 控制夹爪力矩
+        data.ctrl[left_act_id] = current_phase["left_torque"]
+        data.ctrl[right_act_id] = current_phase["right_torque"]
+
+        # 执行仿真步
         mujoco.mj_step(model, data)
         viewer.sync()
-        time.sleep(0.005)
-        step += 1
+        time.sleep(STEP_DELAY)
 
+        # 阶段步数递增 & 阶段切换
+        phase_step += 1
+        if phase_step >= current_phase["steps"]:
+            phase_step = 0
+            current_phase_idx = (current_phase_idx + 1) % len(phase_list)
+
+    # 关闭可视化窗口
     viewer.close()
+    print("\n✅ 夹爪控制测试结束")
 
+
+# ===================== 程序入口 =====================
 if __name__ == "__main__":
-    main()
+    gripper_control_test()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 配置集中化（易修改）
所有可调参数（模型路径、相机参数、运动速度、各阶段时长 / 力矩）都放在顶部配置项区域，无需深入代码即可调整：
想放慢夹爪速度：修改STEP_DELAY = 0.01；
想延长闭合保持时间：修改hold阶段的steps为 500；
想增大夹爪力矩：修改left_torque/right_torque为 2.0（匹配模型ctrlrange）。
2. 鲁棒性大幅提升（防出错）
模型加载增加文件存在性检查 + 异常捕获，并给出清晰的错误提示（比如路径错误、执行器名称错误）；
兼容新旧版本的 MuJoCo viewer（自动切换launch/launch_passive），避免版本兼容报错；
获取执行器 ID 增加异常处理，防止模型中执行器名称不匹配导致崩溃。
3. 逻辑简化 + 易扩展（易维护）
移除冗余的if-elif嵌套，改用阶段列表 + 索引循环，新增阶段（如 “缓慢张开”）只需在GRIPPER_PHASES中添加一行配置，无需修改循环逻辑；
阶段内步数单独计数，避免全局step重置的混乱；
只在阶段开始时打印一次提示，避免刷屏，输出更清晰。
4. 可读性优化（易理解）
函数 / 变量名语义化（如gripper_control_test/current_phase_idx）；
关键逻辑添加中文注释，新手能快速定位 “加载模型→获取执行器→阶段控制→仿真运行” 的核心流程；
打印信息更友好，包含阶段剩余步数、操作说明，便于观察运行状态。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1920" height="1080" alt="Desktop Screenshot 2026 03 06 - 12 21 15 22" src="https://github.com/user-attachments/assets/37486e19-1a7a-4867-a250-6470f3453f1f" />
