### PR TITLE
添加命令行参数支持

### DIFF
--- a/src/Yolov3_Autonomous_Vehicle_Object_Detection/main.py
+++ b/src/Yolov3_Autonomous_Vehicle_Object_Detection/main.py
@@ -3,19 +3,36 @@ import time
 import queue
 import numpy as np
 import carla
+import argparse  # [新增] 引入命令行参数解析库
 
 from config import config
 from utils.carla_client import CarlaClient
 from models.yolo_detector import YOLODetector
-# [新增] 引入新的绘图函数
 from utils.visualization import draw_results, draw_safe_zone
 from utils.planner import SimplePlanner
 from utils.logger import PerformanceLogger
 
 
+# [新增] 参数解析函数
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Autonomous Vehicle Object Detection System")
+
+    parser.add_argument("--host", default=config.CARLA_HOST, help="CARLA Host IP")
+    parser.add_argument("--port", type=int, default=config.CARLA_PORT, help="CARLA Port")
+    parser.add_argument("--no-render", action="store_true", help="Disable OpenCV rendering window (Headless mode)")
+
+    return parser.parse_args()
+
+
 def main():
-    # 1. 初始化模块
+    # 1. 解析命令行参数
+    args = parse_arguments()
+
     print("[Main] 初始化模块...")
+    # 打印运行模式
+    if args.no_render:
+        print("[INFO] 运行模式: Headless (无窗口渲染)")
+
     detector = YOLODetector(
         cfg_path=config.YOLO_CONFIG_PATH,
         weights_path=config.YOLO_WEIGHTS_PATH,
@@ -27,7 +44,9 @@ def main():
 
     planner = SimplePlanner()
     logger = PerformanceLogger(log_dir=config.LOG_DIR)
-    client = CarlaClient()
+
+    # [Mod] 使用命令行参数初始化客户端
+    client = CarlaClient(host=args.host, port=args.port)
 
     if not client.connect():
         return
@@ -63,23 +82,20 @@ def main():
                 fps = 1 / (time.time() - start_time)
                 logger.log_step(fps, len(results))
 
-                # --- 可视化 ---
-                # 1. 先画安全走廊 (蓝色辅助线)
-                frame = draw_safe_zone(frame)
+                # --- 可视化 (根据 --no-render 参数决定是否显示) ---
+                if not args.no_render:
+                    frame = draw_safe_zone(frame)
+                    frame = draw_results(frame, results, detector.classes)
 
-                # 2. 再画检测框
-                frame = draw_results(frame, results, detector.classes)
+                    cv2.putText(frame, f"FPS: {fps:.2f}", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
+                    if is_brake:
+                        cv2.putText(frame, "EMERGENCY BRAKING!", (150, 300), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (0, 0, 255),
+                                    4)
+                        cv2.putText(frame, warning_msg, (180, 350), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 255), 2)
 
-                # 3. 画 FPS 和警告
-                cv2.putText(frame, f"FPS: {fps:.2f}", (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 0, 255), 2)
-                if is_brake:
-                    cv2.putText(frame, "EMERGENCY BRAKING!", (150, 300), cv2.FONT_HERSHEY_SIMPLEX, 1.5, (0, 0, 255), 4)
-                    cv2.putText(frame, warning_msg, (180, 350), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 255), 2)
-
-                cv2.imshow("CARLA Object Detection", frame)
-
-                if cv2.waitKey(1) & 0xFF == ord('q'):
-                    break
+                    cv2.imshow("CARLA Object Detection", frame)
+                    if cv2.waitKey(1) & 0xFF == ord('q'):
+                        break
 
             except queue.Empty:
                 continue
@@ -91,7 +107,9 @@ def main():
         print("[Main] 正在清理资源...")
         client.destroy_actors()
         logger.close()
-        cv2.destroyAllWindows()
+        # 只有创建了窗口才需要销毁
+        if not args.no_render:
+            cv2.destroyAllWindows()
         print("[Main] 程序已退出")
 
 

--- a/src/Yolov3_Autonomous_Vehicle_Object_Detection/utils/carla_client.py
+++ b/src/Yolov3_Autonomous_Vehicle_Object_Detection/utils/carla_client.py
@@ -20,9 +20,11 @@ class CarlaClient:
     CARLA 模拟器客户端封装类
     """
 
-    def __init__(self):
-        self.host = config.CARLA_HOST
-        self.port = config.CARLA_PORT
+    # [Mod] 修改 __init__ 方法，允许覆盖 host 和 port
+    def __init__(self, host=None, port=None):
+        # 如果传入了参数就用传入的，否则用 config 里的默认值
+        self.host = host if host else config.CARLA_HOST
+        self.port = port if port else config.CARLA_PORT
         self.timeout = config.CARLA_TIMEOUT
 
         self.client = None
@@ -50,7 +52,6 @@ class CarlaClient:
             print("[ERROR] 世界未加载，请先连接！")
             return None
 
-        # [Refactor] 使用配置文件中的车型
         model_name = config.VEHICLE_MODEL
         bp = self.blueprint_library.find(model_name)
 
@@ -74,7 +75,6 @@ class CarlaClient:
         camera_bp.set_attribute('image_size_y', str(config.CAMERA_HEIGHT))
         camera_bp.set_attribute('fov', str(config.CAMERA_FOV))
 
-        # [Refactor] 使用配置文件中的安装位置
         spawn_point = carla.Transform(carla.Location(x=config.CAMERA_POS_X, z=config.CAMERA_POS_Z))
 
         self.camera = self.world.spawn_actor(camera_bp, spawn_point, attach_to=self.vehicle)


### PR DESCRIPTION
修改概述: 引入 `argparse` 库，使系统支持通过命令行参数动态配置连接信息和运行模式。

## 修改的详细描述
1. **参数解析集成 (`main.py`)**:
   - 新增 `parse_arguments()` 函数。
   - 支持 `--host` 和 `--port`: 允许在不修改代码的情况下连接远程 CARLA 服务器。
   - 支持 `--no-render`: 新增 "Headless Mode"（无头模式），允许在没有显示器的服务器上运行检测算法，仅记录日志而不弹出 OpenCV 窗口。

2. **客户端增强 (`utils/carla_client.py`)**:
   - 修改 `__init__` 方法，使其接受可变参数 `host` 和 `port`，提高了类的通用性。

## 经过了什么样的测试？
1. **默认模式**:
   - 运行 `python main.py` -> 正常弹出窗口。
2. **无头模式**:
   - 运行 `python main.py --no-render`。
   - **结果**: 程序正常启动，控制台显示 FPS 日志，但未弹出 OpenCV 窗口。
   - 验证了该功能适用于后台长时间挂机测试。

## 运行效果
<img width="1194" height="936" alt="image" src="https://github.com/user-attachments/assets/f70fbcf9-f918-4566-a8f7-88028e518796" />
<img width="2176" height="468" alt="image" src="https://github.com/user-attachments/assets/10bd8ad2-4a2d-491e-9ef0-08cb1fc8d447" />
