### PR TITLE
fix: use cumulative simulation time in Robotic_arm

### DIFF
--- a/src/Robotic_arm/main.py
+++ b/src/Robotic_arm/main.py
@@ -624,6 +624,12 @@ class ArmJointPerfOptimizationController:
         write_perf_log(f"末端负载更新为{mass}kg")
         print(f"✅ 末端负载更新为{mass}kg")
 
+    def get_total_sim_time(self):
+        """获取累计仿真时间，优先使用MuJoCo内部时间"""
+        if self.data is not None:
+            return float(self.data.time)
+        return self.total_sim_time
+
     def print_perf_status(self):
         """打印运动性能状态"""
         current_time = time.time()
@@ -632,7 +638,7 @@ class ArmJointPerfOptimizationController:
 
         self.fps_counter = max(1, self.fps_counter)
         fps = self.fps_counter / (current_time - self.last_print_time)
-        self.total_sim_time = current_time - self.last_print_time
+        self.total_sim_time = self.get_total_sim_time()
         joint_angles = self.get_current_joint_angles(use_deg=True)
         joint_vels = self.get_current_joint_velocities(use_deg=True)
         pos_error_deg = rad2deg(self.position_error)
@@ -715,6 +721,7 @@ class ArmJointPerfOptimizationController:
                 write_perf_log(error_msg)
                 continue
 
+        self.total_sim_time = self.get_total_sim_time()
         # 资源清理
         self.cleanup()
         final_msg = f"仿真结束 | 总步数{self.step_count:,} | 总时间{self.total_sim_time:.2f}s | 最大定位误差{np.round(rad2deg(np.max(self.max_position_error)), 4)}°"


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!--修复 `src/Robotic_arm/main.py` 中“总仿真时间”统计口径错误的问题，避免将“距离上次打印的时间间隔”误显示为累计总时长。-->

## 修改的详细描述
1. 在 `src/Robotic_arm/main.py` 中新增 `get_total_sim_time()`，统一获取累计仿真时间。
2. 将运行过程中的“总仿真时间”改为优先使用 MuJoCo 内部累计时间 `self.data.time`。
3. 在仿真结束前再次刷新 `self.total_sim_time`，确保最终总结中的总时间与实际累计仿真时间一致。
4. 本次修改仅涉及 `Robotic_arm` 模块的时间统计逻辑，不影响原有控制流程和运动逻辑。

<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：Linux 6.8.0-106-generic x86_64 GNU/Linux
2. Python版本：Python 3.10.12
3. 测试方式：
   - 执行 `python3 -m py_compile src/Robotic_arm/main.py`
   - 人工检查代码逻辑，确认运行中统计和结束统计使用同一套累计时间口径
4. 提交版本：`e83e8787`
<!-- 请描述所做修改的测试，便于合并 -->
1. 运行过程中输出的“总仿真时间”会随着仿真持续累积增长，不再是上一次打印间隔。
2. 仿真结束后的“总时间”统计与运行过程中的时间口径保持一致。
## 运行效果
动图、视频、截图等
<img width="1274" height="742" alt="图片" src="https://github.com/user-attachments/assets/4d5024d1-d779-4104-97b1-22b1cfb11cd8" />

