### PR TITLE
Add: 增强 MuJoCo 启动脚本，添加版本检测和错误处理

### DIFF
--- a/run_mujoco.bat
+++ b/run_mujoco.bat
@@ -2,15 +2,72 @@ chcp 65001
 @echo off
 setlocal enabledelayedexpansion
 
+REM ========================================
+REM MuJoCo 版本配置
+REM ========================================
+set MUJOCO_VERSION=3.3.7
+set MUJOCO_DIR=mujoco-%MUJOCO_VERSION%-windows-x86_64
+set MUJOCO_ZIP=%MUJOCO_DIR%.zip
+set MUJOCO_REPO=https://github.com/google-deepmind/mujoco/releases/download/%MUJOCO_VERSION%/%MUJOCO_DIR%.zip
+set MUJOCO_EXE=.\%MUJOCO_DIR%\bin\simulate.exe
 
-set MUJOCO_TEMP_FILE_DIR=mujoco-3.3.7-windows-x86_64.zip
-set MUJOCO_REPO=https://github.com/google-deepmind/mujoco/releases/download/3.3.7/mujoco-3.3.7-windows-x86_64.zip
+REM ========================================
+REM 版本检测函数
+REM ========================================
+:check_version
+echo [INFO] Checking MuJoCo version %MUJOCO_VERSION%...
 
-if not exist "%MUJOCO_TEMP_FILE_DIR%" (
-    echo %FILE_N% Retrieving mujoco from %MUJOCO_REPO% ...
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%MUJOCO_REPO%', '%MUJOCO_TEMP_FILE_DIR%')"
+REM 检查可执行文件是否存在
+if exist "%MUJOCO_EXE%" (
+    echo [OK] MuJoCo %MUJOCO_VERSION% found at: %MUJOCO_DIR%
+    goto :run_mujoco
 )
 
-powershell -Command "Expand-Archive '%MUJOCO_TEMP_FILE_DIR%' -DestinationPath '.' -Force"
+REM 检查解压目录是否存在但可执行文件缺失
+if exist "%MUJOCO_DIR%" (
+    echo [WARN] Directory exists but simulate.exe missing, re-downloading...
+    rmdir /s /q "%MUJOCO_DIR%" 2>nul
+)
 
-call .\bin\simulate.exe
+REM 检查是否需要下载
+if not exist "%MUJOCO_ZIP%" (
+    echo [INFO] Downloading MuJoCo %MUJOCO_VERSION%...
+    echo [INFO] URL: %MUJOCO_REPO%
+    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%MUJOCO_REPO%', '%MUJOCO_ZIP%')"
+    if !errorlevel! neq 0 (
+        echo [ERROR] Download failed! Please check network connection.
+        exit /b 1
+    )
+    echo [OK] Download completed.
+) else (
+    echo [OK] Archive already exists: %MUJOCO_ZIP%
+)
+
+REM 解压
+echo [INFO] Extracting %MUJOCO_ZIP%...
+powershell -Command "Expand-Archive '%MUJOCO_ZIP%' -DestinationPath '.' -Force"
+if !errorlevel! neq 0 (
+    echo [ERROR] Extraction failed!
+    exit /b 1
+)
+
+REM 再次验证
+if not exist "%MUJOCO_EXE%" (
+    echo [ERROR] simulate.exe not found after extraction!
+    exit /b 1
+)
+echo [OK] Extraction completed.
+
+REM ========================================
+REM 运行 MuJoCo
+REM ========================================
+:run_mujoco
+echo [INFO] Launching MuJoCo simulate...
+call "%MUJOCO_EXE%"
+if !errorlevel! neq 0 (
+    echo [ERROR] Failed to launch MuJoCo!
+    exit /b 1
+)
+
+echo [INFO] MuJoCo closed.
+exit /b 0


### PR DESCRIPTION
修改的详细描述
1. 添加 MUJOCO_VERSION 变量统一管理版本号（当前为 3.3.7），便于后续升级维护
2. 添加版本检测逻辑：运行前检查 simulate.exe 是否存在，避免重复下载/解压
3. 添加各阶段错误处理：下载失败、解压失败、启动失败均有明确提示和退出码
4. 优化输出信息：添加 [INFO]、[OK]、[WARN]、[ERROR] 前缀，便于排查问题
经过了什么样的测试?
1. 操作系统：Windows 11
2. 批处理语法验证通过（变量定义、标签、错误处理、退出码）
3. 逻辑完整性检查通过
