### PR TITLE
更新yolo12-A2C2f-DFFN模型

### DIFF
--- a/src/yolo12_object_detection/README.md
+++ b/src/yolo12_object_detection/README.md
@@ -6,6 +6,11 @@
 
 本项目使用 [CARLA Object Detection Dataset](https://github.com/DanielHfnr/Carla-Object-Detection-Dataset) 数据集，通过 Google Drive 整理版本进行下载，结合 YOLO12 模型进行自动驾驶场景下的目标检测任务。
 
+**新增自定义模型**：项目中包含多个改进的 YOLO12 模型：
+- `yolo12-A2C2f-CGLU.yaml`：在标准 YOLO12 基础上使用 A2C2f_CGLU 模块替换 A2C2f 模块
+- `yolo12-A2C2f-DFFN.yaml`：在标准 YOLO12 基础上使用 A2C2f_DFFN 模块替换 A2C2f 模块
+以上模型均预设类别数为 5，适配 CARLA 数据集（vehicle, bike, motobike, traffic_light, traffic_sign）。
+
 数据集来源于：[https://github.com/DanielHfnr/Carla-Object-Detection-Dataset](https://github.com/DanielHfnr/Carla-Object-Detection-Dataset)
 
 ## 环境要求

--- a/src/yolo12_object_detection/scripts/train.py
+++ b/src/yolo12_object_detection/scripts/train.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     script_dir = os.path.dirname(__file__)
     data_yaml_abs = os.path.abspath(os.path.join(script_dir, '../dataset/data.yaml'))
 
-    model = YOLO('ultralytics/cfg/models/12/yolo12-A2C2f-CGLU.yaml')
+    model = YOLO('ultralytics/cfg/models/12/yolo12-A2C2f-DFFN.yaml')
     model.train(data=data_yaml_abs,  # 使用绝对路径
                 amp=False,
                 cache=False,
@@ -19,5 +19,5 @@ if __name__ == '__main__':
                 workers=4,
                 optimizer='SGD',
                 project='runs/train',
-                name='CGLU',
+                name='DFFN',
                 )

--- a/src/yolo12_object_detection/scripts/ultralytics/cfg/models/12/yolo12-A2C2f-DFFN.yaml
+++ b/src/yolo12_object_detection/scripts/ultralytics/cfg/models/12/yolo12-A2C2f-DFFN.yaml
@@ -1,0 +1,45 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# YOLO12 object detection model with P3/8 - P5/32 outputs
+# Model docs: https://docs.ultralytics.com/models/yolo12
+# Task docs: https://docs.ultralytics.com/tasks/detect
+
+# Parameters
+nc: 5 # number of classes
+scales: # model compound scaling constants, i.e. 'model=yolo12n.yaml' will call yolo12.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.50, 0.25, 1024] # summary: 272 layers, 2,602,288 parameters, 2,602,272 gradients, 6.7 GFLOPs
+
+
+# YOLO12n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv,  [64, 3, 2]] # 0-P1/2
+  - [-1, 1, Conv,  [128, 3, 2, 1, 2]] # 1-P2/4
+  - [-1, 2, C3k2,  [256, False, 0.25]]
+  - [-1, 1, Conv,  [256, 3, 2, 1, 4]] # 3-P3/8
+  - [-1, 2, C3k2,  [512, False, 0.25]]
+  - [-1, 1, Conv,  [512, 3, 2]] # 5-P4/16
+  - [-1, 4, A2C2f_DFFN, [512, True, 4]]
+  - [-1, 1, Conv,  [1024, 3, 2]] # 7-P5/32
+  - [-1, 4, A2C2f_DFFN, [1024, True, 1]] # 8
+
+# YOLO12n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 6], 1, Concat, [1]] # cat backbone P4
+  - [-1, 2, A2C2f_DFFN, [512, False, -1]] # 11
+
+  - [-1, 1, nn.Upsample, [None, 2, "nearest"]]
+  - [[-1, 4], 1, Concat, [1]] # cat backbone P3
+  - [-1, 2, A2C2f_DFFN, [256, False, -1]] # 14
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 11], 1, Concat, [1]] # cat head P4
+  - [-1, 2, A2C2f_DFFN, [512, False, -1]] # 17
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 8], 1, Concat, [1]] # cat head P5
+  - [-1, 2, C3k2, [1024, True]] # 20 (P5/32-large)
+
+  - [[14, 17, 20], 1, Detect, [nc]] # Detect(P3, P4, P5)


### PR DESCRIPTION
## 修改的详细描述
1. 新增自定义 YOLO12 模型 `yolo12-A2C2f-DFFN.yaml`，使用 A2C2f_DFFN 模块替换标准 A2C2f 模块
2. 预设模型类别数为 5，适配 CARLA 数据集（vehicle, bike, motobike, traffic_light, traffic_sign）
3. 更新 README.md，添加对新模型的说明

## 经过了什么样的测试?
1. 操作系统：Windows 10 Pro 10.0.19045
2. Python版本：3.11+
3. 测试内容：验证模型配置文件语法正确性、模块定义完整性

## 运行效果
<img width="1849" height="1040" alt="9654c67323c986d4ae54bd5828a6e997" src="https://github.com/user-attachments/assets/450d1b58-a53e-497c-b84b-c59295f72817" />
