### PR TITLE
完成选题，新增机器人摔倒检测功能，优化高度判定阈值

### DIFF
--- a/src/mujoco01/main.py
+++ b/src/mujoco01/main.py
@@ -23,7 +23,7 @@ def main():
     # 加载MJCF模型文件
     # 模型定义了完整的人形机器人结构：包括躯干、四肢、关节和执行器
     try:
-        model = mujoco.MjModel.from_xml_path("mujoco01\humanoid.xml")
+        model = mujoco.MjModel.from_xml_path("src/mujoco01/humanoid.xml")
     except Exception as e:
         print(f"模型加载失败: {e}")
         return
@@ -52,6 +52,11 @@ def main():
             print(f"时间: {data.time:.2f}, "
                 f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
             
+            # 摔倒检测：躯干高度低于 0.2 米判定摔倒
+            if data.qpos[2] < 0.2:
+                print("⚠️ 机器人摔倒了！")
+                break
+
             # 更新可视化窗口
             # 将当前模拟状态同步到视图
             v.sync()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件! 这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南: https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:
本 PR 为 mujoco01 人形机器人模拟项目，新增了机器人摔倒检测功能，并优化了躯干高度判定阈值，避免了初始深蹲姿态下的误判问题。

## 修改的详细描述
1.  在 `src/mujoco01/main.py` 的主模拟循环中，新增了机器人摔倒检测逻辑。
2.  以机器人躯干高度（`data.qpos[2]`）为判断依据，将摔倒判定阈值从初始的 0.5 米优化调整为 0.2 米，避免了机器人初始深蹲姿态导致的误判。
3.  当检测到机器人躯干高度低于阈值时，会打印摔倒提示信息并终止模拟，便于用户及时观察和调试。
4.  新增的检测逻辑不影响原有模拟流程，仅在触发条件时输出提示并退出，对其他功能无影响。

## 经过了什么样的测试?
1.  操作系统：Windows 10
2.  Python 版本：3.10
3.  测试结果：模拟程序可正常启动运行，初始深蹲姿态无误判；人为设置摔倒条件后，程序可正确检测并打印提示信息，功能符合预期。

## 运行效果
模拟运行过程中，控制台会实时打印机器人躯干位置信息；当机器人躯干高度低于 0.2 米时，会打印 `机器人摔倒了！` 提示并终止模拟。
<img width="1425" height="1007" alt="image" src="https://github.com/user-attachments/assets/ab07544f-ab54-43fc-8254-f88c943be081" />
<img width="554" height="298" alt="屏幕截图 2026-04-22 003211" src="https://github.com/user-attachments/assets/0cc6e931-7175-4423-9125-ee38897dd0ed" />



