### PR TITLE
docs(index): 将V2X路侧智能感知添加到首页感知章节导航

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ title: 主页
 
 [__carla_CAM__](./carla_CAM/README.md) - 使用类激活映射测试卷积神经网络
 
+[__V2X路侧智能感知__](./edge_intelligence_V2X/README.md) - 基于YOLOv8n的V2X路侧智能感知系统优化与实现
+
 [__目标检测__](./test/object_detection.md) - 目标检测与危险评估
 
 [__跟踪__](#tracking) 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,6 @@ copyright: OpenHUTB 版权所有 &copy; {year}
 
 nav:
 - 首页: 'index.md'
-- V2X路侧智能感知: 'edge_intelligence_V2X/README.md'
 
 
 # - mdx_math 用于行内公式显示


### PR DESCRIPTION
## 修改说明

调整 `edge_intelligence_V2X` 模块在文档导航中的位置，使其与其他模块保持一致的层级结构。

### 变更内容

**`docs/index.md`**
- 在感知章节（`## 感知`）下新增 V2X 路侧智能感知的入口链接，与 `carla_CAM`、目标检测等模块并列

**`mkdocs.yml`**
- 移除原来与首页并列的顶级 `nav` 条目 `V2X路侧智能感知`
- 改为通过首页感知章节的链接访问，与仓库其他模块的导航方式保持一致

### 效果

用户访问 https://openhutb.github.io/nn/ 首页 → 感知章节 → 点击「V2X路侧智能感知」→ 跳转到对应文档页面。