### PR TITLE
chap03：优化 SVM 参数配置与结果留档

### DIFF
--- a/src/chap03_SVM/README.md
+++ b/src/chap03_SVM/README.md
@@ -1,5 +1,26 @@
 # 支持向量机 (SVM)
 
+## 工程化小改动（第三次提交）
+
+本次在不改变 SVM 核心训练逻辑的前提下，对 `svm.py` 做了轻量改进，方便复现实验和作业提交。
+
+1. 新增命令行参数入口：
+`--train-file`、`--test-file`、`--learning-rate`、`--reg-lambda`、`--max-iter`、`--out-dir`
+2. 将 SVM 超参数改为可配置：
+学习率、正则化系数、最大迭代次数无需手动修改源码
+3. 新增实验结果自动留档：
+运行后自动生成 `outputs/svm_metrics.json`
+
+### 运行示例
+
+```bash
+python svm.py --learning-rate 0.1 --reg-lambda 0.0 --max-iter 20000 --out-dir outputs
+```
+
+### 输出文件
+
+- `outputs/svm_metrics.json`
+
 ## 问题描述
 
 本项目完成了以下三个部分的实验内容：

--- a/src/chap03_SVM/svm.py
+++ b/src/chap03_SVM/svm.py
@@ -1,5 +1,8 @@
 import numpy as np
 import os
+import argparse
+import json
+from pathlib import Path
 from sklearn.preprocessing import StandardScaler
 
 def load_data(fname):
@@ -33,11 +36,11 @@ def eval_acc(label, pred):
 class SVM:
     """SVM模型：基于最大间隔分类的监督学习算法。"""
 #支持向量机（Support Vector Machine, SVM） 是一种经典的监督学习算法，主要用于分类（也可用于回归和异常检测）。
-    def __init__(self):
+    def __init__(self, learning_rate=0.1, reg_lambda=0.0, max_iter=20000):
         # 超参数设置
-        self.learning_rate = 0.1   # 提高学习率以加快收敛
-        self.reg_lambda = 0.0      # 去除正则化以最大化训练集准确率
-        self.max_iter = 20000      # 增加迭代次数以寻求更优解
+        self.learning_rate = learning_rate
+        self.reg_lambda = reg_lambda
+        self.max_iter = max_iter
         self.w = None              # 权重向量，决定分类超平面的方向
         self.b = None              # 偏置项，决定分类超平面的位置
         self.scaler = StandardScaler() # 添加标准化器
@@ -114,9 +117,21 @@ class SVM:
 
 if __name__ == '__main__':
     # 数据加载部分以及数据路径配置
-    base_dir = os.path.dirname(os.path.abspath(__file__))             # 获取当前脚本的绝对路径
-    train_file = os.path.join(base_dir, 'data', 'train_linear.txt')   # 拼接训练数据文件路径
-    test_file = os.path.join(base_dir, 'data', 'test_linear.txt')     # 拼接测试数据文件路径
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    default_train = os.path.join(base_dir, 'data', 'train_linear.txt')
+    default_test = os.path.join(base_dir, 'data', 'test_linear.txt')
+
+    parser = argparse.ArgumentParser(description='Linear SVM training script')
+    parser.add_argument('--train-file', type=str, default=default_train, help='训练集文件路径')
+    parser.add_argument('--test-file', type=str, default=default_test, help='测试集文件路径')
+    parser.add_argument('--learning-rate', type=float, default=0.1, help='学习率')
+    parser.add_argument('--reg-lambda', type=float, default=0.0, help='L2正则化系数')
+    parser.add_argument('--max-iter', type=int, default=20000, help='最大迭代次数')
+    parser.add_argument('--out-dir', type=str, default='outputs', help='结果输出目录')
+    args = parser.parse_args()
+
+    train_file = args.train_file if os.path.isabs(args.train_file) else os.path.join(base_dir, args.train_file)
+    test_file = args.test_file if os.path.isabs(args.test_file) else os.path.join(base_dir, args.test_file)
 
     # 加载训练数据
     data_train = load_data(train_file)
@@ -124,7 +139,11 @@ if __name__ == '__main__':
     data_test = load_data(test_file)
 
     # 模型训练
-    svm = SVM()            # 初始化SVM模型
+    svm = SVM(
+        learning_rate=args.learning_rate,
+        reg_lambda=args.reg_lambda,
+        max_iter=args.max_iter,
+    )
     svm.train_with_label_tracking(data_train)  # 训练模型寻找最优超平面
 
     # 训练集评估
@@ -143,4 +162,21 @@ if __name__ == '__main__':
     
     print("train accuracy: {:.1f}%".format(acc_train * 100))  # 输出训练集准确率
     print("test accuracy: {:.1f}%".format(acc_test * 100))  # 输出测试集准确率
+
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    metrics_path = out_dir / 'svm_metrics.json'
+    metrics = {
+        'train_accuracy': float(acc_train),
+        'test_accuracy': float(acc_test),
+        'learning_rate': float(args.learning_rate),
+        'reg_lambda': float(args.reg_lambda),
+        'max_iter': int(args.max_iter),
+        'train_file': str(train_file),
+        'test_file': str(test_file),
+    }
+    with metrics_path.open('w', encoding='utf-8') as f:
+        json.dump(metrics, f, ensure_ascii=False, indent=2)
+    print(f"metrics saved: {metrics_path.resolve()}")
 


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->对 `src/chap03_SVM/svm.py` 做轻量工程化改进：在不改变 SVM 核心训练逻辑的前提下，增加参数可配置能力和实验结果留档能力。
<!-- Fixes: # -->同步更新 `src/chap03_SVM/README.md`，补充本次改动说明、运行命令和输出文件说明。

## 修改的详细描述
1. `svm.py` 增加命令行参数入口（`argparse`）：
   - `--train-file`
   - `--test-file`
   - `--learning-rate`
   - `--reg-lambda`
   - `--max-iter`
   - `--out-dir`
   
   同时将 `SVM` 类中的超参数由固定值改为可配置参数，避免反复手动修改源码。

2. 新增结果自动保存逻辑：
   - 运行结束后自动在输出目录生成 `svm_metrics.json`，记录训练/测试准确率及关键超参数，便于实验复现与提交留档。

3. 更新 `README.md`：
   - 新增“工程化小改动（第三次提交）”说明；
   - 补充运行示例命令；
   - 补充输出文件说明。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：`Microsoft Windows NT 10.0.19045.0`
2. Python版本：`Python 3.9.0`
3. 依赖环境：`numpy`、`scikit-learn`
4. 测试命令（在 `src/chap03_SVM` 目录）：
   ```bash
   python svm.py --learning-rate 0.1 --reg-lambda 0.0 --max-iter 20000 --out-dir outputs
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="833" height="205" alt="581835492-db852022-a8d5-49dd-bb73-a6c7a05f88c2" src="https://github.com/user-attachments/assets/d90ac83f-7afd-4d71-95da-cadf30753b3f" />
