### PR TITLE
调整关节角度范围与电机齿轮比，优化机器人控制参数

### DIFF
--- a/src/mujoco01/humanoid.xml
+++ b/src/mujoco01/humanoid.xml
@@ -14,7 +14,7 @@
 -->
 
 <mujoco model="Humanoid">
-  <option timestep="0.005" gravity="0 0 -9.0"/>
+  <option timestep="0.005"/>
 
   <visual>
     <map force="0.1" zfar="30"/>
@@ -25,9 +25,9 @@
   <statistic center="0 0 0.7"/>
 
   <asset>
-    <texture type="skybox" builtin="gradient" rgb1=".2 .4 .8" rgb2="0 0 0" width="32" height="512"/>
-    <texture name="body" type="cube" builtin="flat" mark="cross" width="128" height="128" rgb1="0.3 0.6 0.9" rgb2="0.3 0.6 0.9" markrgb="1 1 1"/>
-    <material name="body" texture="body" texuniform="true" rgba="0.3 0.6 0.9 1"/>
+    <texture type="skybox" builtin="gradient" rgb1=".3 .5 .7" rgb2="0 0 0" width="32" height="512"/>
+    <texture name="body" type="cube" builtin="flat" mark="cross" width="128" height="128" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" markrgb="1 1 1"/>
+    <material name="body" texture="body" texuniform="true" rgba="0.8 0.6 .4 1"/>
     <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
     <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
   </asset>
@@ -37,7 +37,7 @@
     <default class="body">
 
       <!-- geoms -->
-      <geom type="capsule" condim="1" friction="1.2" solimp=".9 .99 .003" solref=".015 1" material="body" group="1"/>
+      <geom type="capsule" condim="1" friction=".7" solimp=".9 .99 .003" solref=".015 1" material="body" group="1"/>
       <default class="thigh">
         <geom size=".06"/>
       </default>
@@ -68,7 +68,8 @@
       <default class="joint_big">
         <joint damping="5" stiffness="10"/>
         <default class="hip_x">
-          <joint range="-30 10"/>
+          <!-- 👉 1. 这里改了关节角度范围 -->
+          <joint range="-35 15"/>
         </default>
         <default class="hip_z">
           <joint range="-60 35"/>
@@ -200,7 +201,8 @@
   </tendon>
 
   <actuator>
-    <motor name="abdomen_z"       gear="40"  joint="abdomen_z"/>
+    <!-- 👉 2. 这里改了电机齿轮比 -->
+    <motor name="abdomen_z"       gear="45"  joint="abdomen_z"/>
     <motor name="abdomen_y"       gear="40"  joint="abdomen_y"/>
     <motor name="abdomen_x"       gear="40"  joint="abdomen_x"/>
     <motor name="hip_x_right"     gear="40"  joint="hip_x_right"/>

--- a/src/mujoco01/humanoid.xml
+++ b/src/mujoco01/humanoid.xml
@@ -14,7 +14,7 @@
 -->
 
 <mujoco model="Humanoid">
-  <option timestep="0.005"/>
+  <option timestep="0.005" gravity="0 0 -9.0"/>
 
   <visual>
     <map force="0.1" zfar="30"/>
@@ -25,9 +25,9 @@
   <statistic center="0 0 0.7"/>
 
   <asset>
-    <texture type="skybox" builtin="gradient" rgb1=".3 .5 .7" rgb2="0 0 0" width="32" height="512"/>
-    <texture name="body" type="cube" builtin="flat" mark="cross" width="128" height="128" rgb1="0.8 0.6 0.4" rgb2="0.8 0.6 0.4" markrgb="1 1 1"/>
-    <material name="body" texture="body" texuniform="true" rgba="0.8 0.6 .4 1"/>
+    <texture type="skybox" builtin="gradient" rgb1=".2 .4 .8" rgb2="0 0 0" width="32" height="512"/>
+    <texture name="body" type="cube" builtin="flat" mark="cross" width="128" height="128" rgb1="0.3 0.6 0.9" rgb2="0.3 0.6 0.9" markrgb="1 1 1"/>
+    <material name="body" texture="body" texuniform="true" rgba="0.3 0.6 0.9 1"/>
     <texture name="grid" type="2d" builtin="checker" width="512" height="512" rgb1=".1 .2 .3" rgb2=".2 .3 .4"/>
     <material name="grid" texture="grid" texrepeat="1 1" texuniform="true" reflectance=".2"/>
   </asset>
@@ -37,7 +37,7 @@
     <default class="body">
 
       <!-- geoms -->
-      <geom type="capsule" condim="1" friction=".7" solimp=".9 .99 .003" solref=".015 1" material="body" group="1"/>
+      <geom type="capsule" condim="1" friction="1.2" solimp=".9 .99 .003" solref=".015 1" material="body" group="1"/>
       <default class="thigh">
         <geom size=".06"/>
       </default>

--- a/src/mujoco01/main.py
+++ b/src/mujoco01/main.py
@@ -7,11 +7,7 @@ from mujoco import viewer
 
 def main():
     """
-<<<<<<< HEAD
-    主函数：加载人形机器人模型并运行物理模拟
-=======
     主函数：加载人形机器人模型并运行物理模拟 
->>>>>>> 59edd6d88ab1de0fff277330649faf17b887b8e6
     """
     # 1. 加载MJCF模型文件
     model_path = "src/mujoco01/humanoid.xml" 
@@ -27,16 +23,8 @@ def main():
     # 3. 启动可视化窗口
     print("启动模拟器...")
     with viewer.launch_passive(model, data) as v:
-<<<<<<< HEAD
-        # 新增：初始化机器人为标准站立姿态（对应keyframe索引1）
-    # 解决开局蹲伏姿态不稳定、易倒地的问题
-        mujoco.mj_resetDataKeyframe(model, data, 1)
-        # 4. 运行模拟循环
-        # (新增) 记录上次打印时间
-=======
         # 初始化机器人为标准站立姿态（keyframe索引1对应站立姿势）
         mujoco.mj_resetDataKeyframe(model, data, 1)
->>>>>>> 59edd6d88ab1de0fff277330649faf17b887b8e6
         last_print_time = 0
         
         while v.is_running():
@@ -46,19 +34,12 @@ def main():
             if data.time - last_print_time > 0.5:
                 print(f"时间: {data.time:.2f}, 躯干高度: {data.qpos[2]:.2f}m")
                 last_print_time = data.time
-<<<<<<< HEAD
-=======
         # 4. 运行模拟循环
->>>>>>> 59edd6d88ab1de0fff277330649faf17b887b8e6
         while v.is_running():
             # 步进物理引擎
             mujoco.mj_step(model, data)
 
-<<<<<<< HEAD
-            # 输出关键模拟数据
-=======
             # 输出关键模拟数据 (注意：每帧输出会导致刷屏)
->>>>>>> 59edd6d88ab1de0fff277330649faf17b887b8e6
             print(f"时间: {data.time:.2f}, "
                   f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
 

--- a/src/mujoco01/main.py
+++ b/src/mujoco01/main.py
@@ -1,71 +1,58 @@
 # 标准库
-# 导入时间模块，用于控制模拟帧率
 import time
 
 # 第三方库
-# 导入MuJoCo核心库，提供物理引擎功能
 import mujoco
-# 从MuJoCo导入可视化工具，用于实时显示模拟过程
 from mujoco import viewer
 
 def main():
     """
     主函数：加载人形机器人模型并运行物理模拟
-    
-    流程：
-    1. 加载XML格式的人形机器人模型文件
-    2. 初始化模拟数据结构
-    3. 设置初始姿势为深蹲姿态
-    4. 启动可视化窗口
-    5. 运行指定时长的模拟循环
-    6. 输出关键模拟数据并更新可视化
     """
-    # 加载MJCF模型文件
-    # 模型定义了完整的人形机器人结构：包括躯干、四肢、关节和执行器
+    # 1. 加载MJCF模型文件
+    model_path = "src/mujoco01/humanoid.xml" 
     try:
-        model = mujoco.MjModel.from_xml_path("src/mujoco01/humanoid.xml")
+        model = mujoco.MjModel.from_xml_path(model_path)
     except Exception as e:
         print(f"模型加载失败: {e}")
         return
-    
-    # 创建与模型对应的动态数据结构
-    # 存储模拟过程中的状态变量（位置、速度、力等）
+
+    # 2. 初始化模拟数据结构
     data = mujoco.MjData(model)
-    
-    # 设置初始姿势为深蹲姿态
-    # 使用keyframe索引0，对应XML中定义的"squat"姿势
-    mujoco.mj_resetDataKeyframe(model, data, 0)
-    
-    # 启动被动式可视化窗口
-    # 被动模式意味着我们手动控制模拟步骤和画面更新
-    # 使用with语句确保资源正确释放
+
+    # 3. 启动可视化窗口
+    print("启动模拟器...")
     with viewer.launch_passive(model, data) as v:
-        # 运行模拟（20秒，按每秒60步计算）
-        # 1200步 ≈ 20秒（模型定义的时间步长为0.005秒）
-        for _ in range(1200):
-            # 推进模拟一步
-            # 该函数执行一次完整的前向动力学计算
+        # 新增：初始化机器人为标准站立姿态（对应keyframe索引1）
+    # 解决开局蹲伏姿态不稳定、易倒地的问题
+        mujoco.mj_resetDataKeyframe(model, data, 1)
+        # 4. 运行模拟循环
+        # (新增) 记录上次打印时间
+        last_print_time = 0
+        
+        while v.is_running():
             mujoco.mj_step(model, data)
-            
-            # 打印机器人关键位置信息
-            # data.qpos存储所有关节的位置，前3个值是躯干位置
+
+            # (修改) 每 0.5 秒打印一次，避免刷屏卡顿
+            if data.time - last_print_time > 0.5:
+                print(f"时间: {data.time:.2f}, 躯干高度: {data.qpos[2]:.2f}m")
+                last_print_time = data.time
+        while v.is_running():
+            # 步进物理引擎
+            mujoco.mj_step(model, data)
+
+            # 输出关键模拟数据
             print(f"时间: {data.time:.2f}, "
-                f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
-            
-            # 摔倒检测：躯干高度低于 0.2 米判定摔倒
+                  f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
+
+            # 5. 摔倒检测：躯干高度低于 0.2 米判定摔倒 (假设根节点是自由关节)
             if data.qpos[2] < 0.2:
-                print("⚠️ 机器人摔倒了！")
+                print("⚠️ 机器人摔倒了！程序结束。")
                 break
 
-            # 更新可视化窗口
-            # 将当前模拟状态同步到视图
+            # 6. 更新可视化窗口并控制帧率
             v.sync()
-            
-            # 控制可视化帧率
-            # 暂停一小段时间，使可视化更流畅（实际模拟不受影响）
-            time.sleep(0.005)
+            time.sleep(model.opt.timestep) # 根据物理步长延时，保持真实时间流速
 
-# 程序入口点
 if __name__ == "__main__":
-    # 调用主函数启动模拟
     main()

--- a/src/mujoco01/main.py
+++ b/src/mujoco01/main.py
@@ -23,7 +23,7 @@ def main():
     # 加载MJCF模型文件
     # 模型定义了完整的人形机器人结构：包括躯干、四肢、关节和执行器
     try:
-        model = mujoco.MjModel.from_xml_path("mujoco01\humanoid.xml")
+        model = mujoco.MjModel.from_xml_path("src/mujoco01/humanoid.xml")
     except Exception as e:
         print(f"模型加载失败: {e}")
         return
@@ -52,6 +52,11 @@ def main():
             print(f"时间: {data.time:.2f}, "
                 f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
             
+            # 摔倒检测：躯干高度低于 0.2 米判定摔倒
+            if data.qpos[2] < 0.2:
+                print("⚠️ 机器人摔倒了！")
+                break
+
             # 更新可视化窗口
             # 将当前模拟状态同步到视图
             v.sync()

--- a/src/mujoco01/main.py
+++ b/src/mujoco01/main.py
@@ -1,71 +1,56 @@
 # 标准库
-# 导入时间模块，用于控制模拟帧率
 import time
 
 # 第三方库
-# 导入MuJoCo核心库，提供物理引擎功能
 import mujoco
-# 从MuJoCo导入可视化工具，用于实时显示模拟过程
 from mujoco import viewer
 
 def main():
     """
-    主函数：加载人形机器人模型并运行物理模拟
-    
-    流程：
-    1. 加载XML格式的人形机器人模型文件
-    2. 初始化模拟数据结构
-    3. 设置初始姿势为深蹲姿态
-    4. 启动可视化窗口
-    5. 运行指定时长的模拟循环
-    6. 输出关键模拟数据并更新可视化
+    主函数：加载人形机器人模型并运行物理模拟 
     """
-    # 加载MJCF模型文件
-    # 模型定义了完整的人形机器人结构：包括躯干、四肢、关节和执行器
+    # 1. 加载MJCF模型文件
+    model_path = "src/mujoco01/humanoid.xml" 
     try:
-        model = mujoco.MjModel.from_xml_path("src/mujoco01/humanoid.xml")
+        model = mujoco.MjModel.from_xml_path(model_path)
     except Exception as e:
         print(f"模型加载失败: {e}")
         return
-    
-    # 创建与模型对应的动态数据结构
-    # 存储模拟过程中的状态变量（位置、速度、力等）
+
+    # 2. 初始化模拟数据结构
     data = mujoco.MjData(model)
-    
-    # 设置初始姿势为深蹲姿态
-    # 使用keyframe索引0，对应XML中定义的"squat"姿势
-    mujoco.mj_resetDataKeyframe(model, data, 0)
-    
-    # 启动被动式可视化窗口
-    # 被动模式意味着我们手动控制模拟步骤和画面更新
-    # 使用with语句确保资源正确释放
+
+    # 3. 启动可视化窗口
+    print("启动模拟器...")
     with viewer.launch_passive(model, data) as v:
-        # 运行模拟（20秒，按每秒60步计算）
-        # 1200步 ≈ 20秒（模型定义的时间步长为0.005秒）
-        for _ in range(1200):
-            # 推进模拟一步
-            # 该函数执行一次完整的前向动力学计算
+        # 初始化机器人为标准站立姿态（keyframe索引1对应站立姿势）
+        mujoco.mj_resetDataKeyframe(model, data, 1)
+        last_print_time = 0
+        
+        while v.is_running():
             mujoco.mj_step(model, data)
-            
-            # 打印机器人关键位置信息
-            # data.qpos存储所有关节的位置，前3个值是躯干位置
+
+            # (修改) 每 0.5 秒打印一次，避免刷屏卡顿
+            if data.time - last_print_time > 0.5:
+                print(f"时间: {data.time:.2f}, 躯干高度: {data.qpos[2]:.2f}m")
+                last_print_time = data.time
+        # 4. 运行模拟循环
+        while v.is_running():
+            # 步进物理引擎
+            mujoco.mj_step(model, data)
+
+            # 输出关键模拟数据 (注意：每帧输出会导致刷屏)
             print(f"时间: {data.time:.2f}, "
-                f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
-            
-            # 摔倒检测：躯干高度低于 0.2 米判定摔倒
+                  f"躯干位置: ({data.qpos[0]:.2f}, {data.qpos[1]:.2f}, {data.qpos[2]:.2f})")
+
+            # 5. 摔倒检测：躯干高度低于 0.2 米判定摔倒 (假设根节点是自由关节)
             if data.qpos[2] < 0.2:
-                print("⚠️ 机器人摔倒了！")
+                print("⚠️ 机器人摔倒了！程序结束。")
                 break
 
-            # 更新可视化窗口
-            # 将当前模拟状态同步到视图
+            # 6. 更新可视化窗口并控制帧率
             v.sync()
-            
-            # 控制可视化帧率
-            # 暂停一小段时间，使可视化更流畅（实际模拟不受影响）
-            time.sleep(0.005)
+            time.sleep(model.opt.timestep) # 根据物理步长延时，保持真实时间流速
 
-# 程序入口点
 if __name__ == "__main__":
-    # 调用主函数启动模拟
     main()


### PR DESCRIPTION
修改概述:
<!-- add this line for each issue your PR solves. -->
调整机器人关节活动范围与电机齿轮比参数，优化控制表现
<!-- Fixes: # -->

## 修改的详细描述
1.  调整了髋关节（hip_x）的角度范围，从 `range="-30 10"` 修改为 `range="-35 15"`，提升了关节的运动自由度，使机器人姿态更灵活。
2.  微调了腹部电机（abdomen_z）的齿轮比，从 `gear="40"` 修改为 `gear="45"`，增强了躯干控制的力矩输出，提升了运动稳定性。

## 经过了什么样的测试?
1.  操作系统：Windows 11
2.  Python版本：3.10
3.  仿真环境：MuJoCo 引擎，修改后模型可正常加载、运行，关节运动无报错，姿态控制效果符合预期。

## 运行效果
- 关节活动范围扩大后，机器人在弯腰、转身动作中的姿态更自然，运动轨迹更平滑。
- 腹部电机齿轮比提升后，躯干控制响应更迅速，抗干扰能力增强，摔倒风险降低。
<img width="2159" height="1370" alt="屏幕截图 2026-04-22 142253" src="https://github.com/user-attachments/assets/bf890acb-0818-4e99-882c-891eff6b7109" />
