### PR TITLE
fix(mujoco_manrun): 映射力矩到actuator ctrl并降低刷屏，改进复位/跌倒恢复稳定性

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -62,7 +62,7 @@ class ROSCmdVelHandler(threading.Thread):
             self.stabilizer.set_state("WALK")  # 默认切换到正常走
 
         # 调试输出
-        if self.stabilizer.data.time % 0.5 < 0.1:  # 避免刷屏，每0.5秒输出一次
+        if hasattr(self.stabilizer, "_should_log") and self.stabilizer._should_log("ros_cmd_vel", 0.5):
             print(
                 f"[ROS指令] 速度={target_speed:.2f} | 转向={target_turn:.2f}rad | 当前步态: {self.stabilizer.gait_mode}")
 
@@ -266,6 +266,10 @@ class HumanoidStabilizer:
         self.model.opt.iterations = 200
         self.model.opt.tolerance = 1e-8
 
+        self._log_last = {}
+        self._fall_cooldown_until = 0.0
+        self._fall_count = 0
+
         # 关节名称映射（原有逻辑完全保留）
         self.joint_names = [
             "abdomen_z", "abdomen_y", "abdomen_x",
@@ -278,6 +282,19 @@ class HumanoidStabilizer:
         ]
         self.joint_name_to_idx = {name: i for i, name in enumerate(self.joint_names)}
         self.num_joints = len(self.joint_names)
+
+        self._actuator_id_by_joint = {}
+        self._actuator_gear_by_joint = {}
+        self._actuator_ctrlrange_by_joint = {}
+        for joint_name in self.joint_names:
+            actuator_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, joint_name)
+            if actuator_id < 0:
+                raise RuntimeError(f"未找到与关节同名的执行器：{joint_name}")
+            self._actuator_id_by_joint[joint_name] = int(actuator_id)
+            self._actuator_gear_by_joint[joint_name] = float(self.model.actuator_gear[actuator_id, 0])
+            self._actuator_ctrlrange_by_joint[joint_name] = self.model.actuator_ctrlrange[actuator_id].astype(
+                np.float64
+            )
 
         # PD控制增益（原有逻辑保留，新增动态增益系数）
         self.kp_roll = 120.0
@@ -420,6 +437,27 @@ class HumanoidStabilizer:
         # 初始化稳定姿态（原有逻辑完全保留）
         self._init_stable_pose()
 
+    def _should_log(self, key, interval_s):
+        now = float(self.data.time)
+        last = float(self._log_last.get(key, -1e9))
+        if (now - last) >= float(interval_s):
+            self._log_last[key] = now
+            return True
+        return False
+
+    def _torques_to_ctrl(self, joint_torques):
+        ctrl = np.zeros(self.model.nu, dtype=np.float64)
+        for joint_name in self.joint_names:
+            joint_idx = self.joint_name_to_idx[joint_name]
+            actuator_id = self._actuator_id_by_joint[joint_name]
+            gear = float(self._actuator_gear_by_joint[joint_name])
+            ctrl_min, ctrl_max = self._actuator_ctrlrange_by_joint[joint_name]
+            max_torque = max(abs(ctrl_min), abs(ctrl_max)) * max(gear, 1e-9)
+            torque = float(np.clip(joint_torques[joint_idx], -max_torque, max_torque))
+            ctrl_val = torque / max(gear, 1e-9)
+            ctrl[actuator_id] = float(np.clip(ctrl_val, ctrl_min, ctrl_max))
+        return ctrl
+
     # ===================== 新增：步态模式切换接口 =====================
     def set_gait_mode(self, mode):
         """切换步态模式"""
@@ -452,11 +490,18 @@ class HumanoidStabilizer:
 
     def _init_stable_pose(self):
         """初始化稳定姿态（原有逻辑完全保留）"""
+        keep_time = float(self.data.time)
         mujoco.mj_resetData(self.model, self.data)
+        self.data.time = keep_time
         self.data.qpos[2] = 1.282
         self.data.qpos[3:7] = [1.0, 0.0, 0.0, 0.0]
         self.data.qvel[:] = 0.0
         self.data.xfrc_applied[:] = 0.0
+        self.integral_roll = 0.0
+        self.integral_pitch = 0.0
+        self.current_sensor_data = {}
+        self.imu_data_buffer.clear()
+        self.foot_data_buffer.clear()
 
         # 腰部关节
         self.joint_targets[self.joint_name_to_idx["abdomen_z"]] = 0.0
@@ -486,6 +531,7 @@ class HumanoidStabilizer:
         self.joint_targets[self.joint_name_to_idx["shoulder1_left"]] = 0.1
         self.joint_targets[self.joint_name_to_idx["shoulder2_left"]] = 0.1
         self.joint_targets[self.joint_name_to_idx["elbow_left"]] = 1.5
+        self.prev_joint_targets = self.joint_targets.copy()
 
         mujoco.mj_forward(self.model, self.data)
 
@@ -634,7 +680,7 @@ class HumanoidStabilizer:
         if current_com_z < self.com_safety_threshold and self.enable_robust_optim:
             current_speed = self.walk_speed * self.speed_reduction_factor
             self.walk_speed = np.clip(current_speed, 0.1, self.walk_speed)
-            if self.data.time % 1 < 0.1:
+            if self._should_log("com_low_speed_reduce", 1.0):
                 print(
                     f"[鲁棒优化] 重心过低({current_com_z:.2f}m)，自动降速到{self.walk_speed:.2f} | 当前步态: {self.gait_mode}")
 
@@ -678,6 +724,8 @@ class HumanoidStabilizer:
         )
 
         # 5. 更新关节目标（原有逻辑保留）
+        if self.gait_mode != "STEP_IN_PLACE":
+            self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = float(np.clip(0.12 * speed_factor, -0.2, 0.2))
         self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.1 + right_hip_offset
         self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.4 - right_hip_offset * 1.2
         self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.0 + right_hip_offset * 0.5
@@ -920,7 +968,7 @@ class HumanoidStabilizer:
             torques[idx] = np.clip(torques[idx], -limit, limit)
 
         # 调试输出（新增步态模式信息）
-        if self.data.time % 1 < 0.1 and self.data.time > self.init_wait_time:
+        if self.data.time > self.init_wait_time and self._should_log("walk_debug", 2.0):
             print(f"=== 行走调试 ===")
             print(
                 f"状态: {self.state} | 步态模式: {self.gait_mode} | 步态相位: {self.gait_phase:.2f} | 速度: {self.walk_speed:.2f} | 转向: {self.turn_angle:.2f}")
@@ -959,7 +1007,7 @@ class HumanoidStabilizer:
                 while time.time() - start_time < self.init_wait_time:
                     alpha = min(1.0, (time.time() - start_time) / self.init_wait_time)
                     torques = self._calculate_stabilizing_torques() * alpha
-                    self.data.ctrl[:] = torques
+                    self.data.ctrl[:] = self._torques_to_ctrl(torques)
                     mujoco.mj_step(self.model, self.data)
                     self.data.qvel[:] *= 0.97
                     v.sync()
@@ -969,11 +1017,11 @@ class HumanoidStabilizer:
                 print("=== 初始稳定完成，可输入控制指令 ===")
                 while self.data.time < self.sim_duration:
                     torques = self._calculate_stabilizing_torques()
-                    self.data.ctrl[:] = torques
+                    self.data.ctrl[:] = self._torques_to_ctrl(torques)
                     mujoco.mj_step(self.model, self.data)
 
                     # 状态监测（新增步态信息）
-                    if self.data.time % 2 < 0.1:
+                    if self._should_log("status", 2.0):
                         com = self.data.subtree_com[0]
                         euler = self.current_sensor_data["imu"][
                             "euler"] if self.current_sensor_data else self._get_root_euler()
@@ -984,17 +1032,21 @@ class HumanoidStabilizer:
                         )
 
                     v.sync()
-                    time.sleep(self.dt * 0.5)
+                    time.sleep(self.dt)
 
                     # 跌倒判定（原有逻辑保留）
+                    if self.data.time < self._fall_cooldown_until:
+                        continue
                     com = self.data.subtree_com[0]
                     euler = self.current_sensor_data["imu"]["euler"] if self.current_sensor_data else self._get_root_euler()
                     if com[2] < 0.4 or abs(euler[0]) > 0.6 or abs(euler[1]) > 0.6:
+                        self._fall_count += 1
                         print(
-                            f"跌倒！时间:{self.data.time:.1f}s | 重心(z):{com[2]:.3f}m | "
+                            f"跌倒！#{self._fall_count} 时间:{self.data.time:.1f}s | 重心(z):{com[2]:.3f}m | "
                             f"最大倾角:{max(abs(euler[0]), abs(euler[1])):.3f}rad | 当前步态:{self.gait_mode}"
                         )
                         self.set_state("STAND")  # 跌倒后自动恢复站立
+                        self._fall_cooldown_until = float(self.data.time) + 1.0
         finally:
             keyboard_handler.running = False
             self.ros_handler.stop()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 控制量正确映射到 MuJoCo actuator ctrl ：原先把“期望关节力矩”直接写进 data.ctrl ，会被 ctrlrange[-1,1] 强行裁剪导致长期饱和，动作发僵/不走。现在按每个 actuator 的 gear 与 ctrlrange 把“力矩→ctrl”做归一化并写入正确的 actuator index（。
2. 抑制“取模窗口”导致的重复打印刷屏 ：把多处 time % N < 0.1 改成基于“上次打印时间”的节流，避免在 0.1s 窗口内每步都打印（状态打印 、行走调试 、重心过低提示6；ROS 打印也同样节流 ）。
3. 站立/复位不再把仿真时间归零 ： mj_resetData 会把 data.time 清零，导致时间“跳回去”和循环条件被拉长；现在复位时保留原 time，并清空传感器缓存/积分项，避免复位后一段时间数据不一致
4. 跌倒恢复加冷却，避免连环跌倒 ：跌倒后设置 1s 冷却窗口，避免刚复位还没稳定就马上再次判倒并刷屏，同时增加跌倒计数便于你观察稳定性
5. 轻微前倾以增强“向前走”的驱动力 ：在非原地踏步模式下，根据速度给 abdomen_y 一个小的前倾目标（幅度限幅），通常能明显改善“走不起来/只在原地摆腿”的情况
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1709" height="1113" alt="dca2517435885ea60c134f90523c4330" src="https://github.com/user-attachments/assets/f7f80862-5b74-41a9-8fbb-973862063573" />
