### PR TITLE
chap02：优化 test_verify 稳定性并补充 README 说明

### DIFF
--- a/src/chap02_linear_regression/README.md
+++ b/src/chap02_linear_regression/README.md
@@ -1,5 +1,25 @@
 # 线性回归
 
+## 本次改进说明
+
+本次提交对 `test_verify.py` 做了轻量化工程改进，不改变原有测试逻辑：
+
+1. 将终端不兼容符号（如 ✓/✗/⊘）替换为 ASCII 标记（`[PASS] / [FAIL] / [SKIP]`），避免 Windows 终端出现 `UnicodeEncodeError`。
+2. 新增可选命令行参数：
+`--json-out`（将测试结果导出为 JSON 文件）
+`--stop-on-fail`（首个失败时立即停止）
+3. 保留原有测试用例集合，仅增强运行稳定性与结果留档能力。
+
+### 示例命令
+
+```bash
+python test_verify.py --json-out outputs/test_verify_report.json
+```
+
+### 输出文件
+
+- `outputs/test_verify_report.json`
+
 ## 问题描述：
 
 有一个函数![image](http://latex.codecogs.com/gif.latex?f%3A%20%5Cmathbb%7BR%7D%5Crightarrow%20%5Cmathbb%7BR%7D) ，使得。现 ![image](http://latex.codecogs.com/gif.latex?y%20%3D%20f%28x%29)在不知道函数 $f(\cdot)$的具体形式，给定满足函数关系的一组训练样本![image](http://latex.codecogs.com/gif.latex?%5Cleft%20%5C%7B%20%5Cleft%20%28%20x_%7B1%7D%2Cy_%7B1%7D%20%5Cright%20%29%2C...%2C%5Cleft%20%28%20x_%7BN%7D%2Cy_%7BN%7D%20%5Cright%20%29%20%5Cright%20%5C%7D%2CN%3D300)，请使用线性回归模型拟合出函数$y=f(x)$。

--- a/src/chap02_linear_regression/test_verify.py
+++ b/src/chap02_linear_regression/test_verify.py
@@ -12,6 +12,8 @@
 
 import sys
 import os
+import argparse
+import json
 from pathlib import Path
 
 # 设置路径
@@ -56,7 +58,7 @@ def test_identity_basis():
     phi = identity_basis(x)
     assert phi.shape == (5, 1), f"Expected (5, 1), got {phi.shape}"
     assert np.allclose(phi.squeeze(), x), "输出值不匹配"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_multinomial_basis():
@@ -67,7 +69,7 @@ def test_multinomial_basis():
     expected = np.array([[2.0, 4.0, 8.0]])
     assert phi.shape == (1, 3), f"Expected (1, 3), got {phi.shape}"
     assert np.allclose(phi, expected), "输出值不匹配"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_gaussian_basis():
@@ -77,7 +79,7 @@ def test_gaussian_basis():
     phi = gaussian_basis(x, feature_num=10)
     assert phi.shape == (5, 10), f"Expected (5, 10), got {phi.shape}"
     assert np.all(phi >= 0) and np.all(phi <= 1), "高斯函数值应在 [0, 1] 范围内"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_least_squares():
@@ -90,7 +92,7 @@ def test_least_squares():
     expected_w = np.array([3, 2])
     assert w.shape == (2,), f"Expected (2,), got {w.shape}"
     assert np.allclose(w, expected_w, atol=1e-5), f"Expected {expected_w}, got {w}"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_gradient_descent():
@@ -103,7 +105,7 @@ def test_gradient_descent():
     assert w.shape == (2,), f"Expected (2,), got {w.shape}"
     # 检查收敛性（允许较大容差）
     assert np.abs(w[0] - 3) < 1.0 and np.abs(w[1] - 2) < 1.0, "梯度下降未收敛"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_main_function():
@@ -115,7 +117,7 @@ def test_main_function():
     assert callable(f), "返回值应该是可调用的函数"
     assert w_lsq is not None, "应返回最小二乘权重"
     assert w_gd is None, "未使用梯度下降时应返回 None"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_main_with_basis():
@@ -125,7 +127,7 @@ def test_main_with_basis():
     y_train = 2 * x_train + 3
     f, w_lsq, w_gd = main(x_train, y_train, basis_func=multinomial_basis)
     assert w_lsq.shape[0] == 11, "多项式基函数应生成 11 个权重（1个偏置 + 10个特征）"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_main_prediction():
@@ -138,7 +140,7 @@ def test_main_prediction():
     y_pred = f(x_test)
     assert y_pred.shape == x_test.shape, "预测输出形状应与输入相同"
     assert np.all(np.isfinite(y_pred)), "预测值应为有限数"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_evaluate():
@@ -149,7 +151,7 @@ def test_evaluate():
     error = evaluate(ys_true, ys_pred)
     assert isinstance(error, (float, np.floating)), "错误应为浮点数"
     assert error > 0, "错误应为正数"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_evaluate_perfect():
@@ -159,7 +161,7 @@ def test_evaluate_perfect():
     ys_pred = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
     error = evaluate(ys_true, ys_pred)
     assert error < 1e-10, "完美预测的错误应接近 0"
-    print("✓ 通过")
+    print("[PASS] 通过")
 
 
 def test_load_data():
@@ -171,16 +173,21 @@ def test_load_data():
         assert isinstance(xs, np.ndarray), "特征应为 numpy 数组"
         assert isinstance(ys, np.ndarray), "标签应为 numpy 数组"
         assert xs.shape[0] == ys.shape[0], "特征和标签数量应相同"
-        print("✓ 通过")
+        print("[PASS] 通过")
     else:
-        print("⊘ 跳过 (data file not found)")
+        print("[SKIP] 跳过 (data file not found)")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Linear regression module verify script")
+    parser.add_argument("--json-out", type=str, default=None, help="Optional: write test report to JSON file")
+    parser.add_argument("--stop-on-fail", action="store_true", help="Stop immediately on first failure")
+    args = parser.parse_args()
+
     print("=" * 60)
-    print("线性回归模块单元测试")
+    print("Linear Regression Module Unit Tests")
     print("=" * 60)
-    
+
     tests = [
         test_identity_basis,
         test_multinomial_basis,
@@ -194,20 +201,39 @@ if __name__ == "__main__":
         test_evaluate_perfect,
         test_load_data,
     ]
-    
+
     passed = 0
     failed = 0
-    
+    results = []
+
     for test_func in tests:
         try:
             test_func()
             passed += 1
+            results.append({"name": test_func.__name__, "status": "passed"})
         except Exception as e:
-            print(f"✗ 失败: {e}")
+            print(f"[FAIL] Failed: {e}")
             failed += 1
-    
+            results.append({"name": test_func.__name__, "status": "failed", "error": str(e)})
+            if args.stop_on_fail:
+                break
+
     print("=" * 60)
-    print(f"测试结果: {passed} 通过, {failed} 失败")
+    print(f"Test summary: {passed} passed, {failed} failed")
     print("=" * 60)
-    
+
+    if args.json_out:
+        out_path = Path(args.json_out)
+        if not out_path.is_absolute():
+            out_path = Path(__file__).parent / out_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "passed": passed,
+            "failed": failed,
+            "total": passed + failed,
+            "results": results,
+        }
+        out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Report saved: {out_path}")
+
     sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->对 `src/chap02_linear_regression/test_verify.py` 做了轻量工程化改进，并同步更新 `README.md` 说明文档，在不改变原有测试逻辑的前提下提升终端兼容性与结果留档能力。
<!-- Fixes: # -->

## 修改的详细描述
1. 更新 `src/chap02_linear_regression/test_verify.py`
   - 将终端不兼容符号（如 `✓/✗/⊘`）替换为 ASCII 标记（`[PASS]/[FAIL]/[SKIP]`），避免 Windows 终端编码报错。
   - 新增命令行参数：
     - `--json-out`：导出测试结果到 JSON 文件；
     - `--stop-on-fail`：首个失败后立即停止。
   - 保持原有测试用例与核心验证逻辑不变，仅增强可用性与可追踪性。

2. 更新 `src/chap02_linear_regression/README.md`
   - 增补“本次改进说明”章节；
   - 增加示例命令与输出文件路径说明，便于复现和提交。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：Windows（PowerShell）
2. Python 版本：Python 3.x（本地 `python` 环境）
3. 测试命令：
   - `python src/chap02_linear_regression/test_verify.py`
   - `python src/chap02_linear_regression/test_verify.py --json-out outputs/test_verify_report.json`
4. 测试结果：
   - 终端输出：`11 passed, 0 failed`
   - 可正常生成测试报告：`outputs/test_verify_report.json`
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1051" height="1151" alt="5cba159e-7a36-48d2-b4a5-93fc2cdaf4da" src="https://github.com/user-attachments/assets/7b9cfef4-6bb0-4469-859c-02d81a8f2667" />
