### PR TITLE
fix(mujoco_manrun): 复位对齐关节qpos并软化起步，增强俯仰纠正以减少前倾跌倒

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -526,16 +526,16 @@ class HumanoidStabilizer:
         # 右腿关节
         self.joint_targets[self.joint_name_to_idx["hip_x_right"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["hip_z_right"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.1
-        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.4
+        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.0
+        self.joint_targets[self.joint_name_to_idx["knee_right"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_x_right"]] = 0.0
 
         # 左腿关节
         self.joint_targets[self.joint_name_to_idx["hip_x_left"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["hip_z_left"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.1
-        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.4
+        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.0
+        self.joint_targets[self.joint_name_to_idx["knee_left"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_x_left"]] = 0.0
 
@@ -548,6 +548,7 @@ class HumanoidStabilizer:
         self.joint_targets[self.joint_name_to_idx["elbow_left"]] = 1.5
         self.prev_joint_targets = self.joint_targets.copy()
 
+        self.data.qpos[7:7 + self.num_joints] = self.joint_targets.astype(np.float64)
         mujoco.mj_forward(self.model, self.data)
 
     # ===================== 传感器模拟相关方法（原有新增逻辑保留） =====================
@@ -741,12 +742,17 @@ class HumanoidStabilizer:
         # 5. 更新关节目标（原有逻辑保留）
         if self.gait_mode != "STEP_IN_PLACE":
             self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = float(np.clip(0.12 * speed_factor, -0.2, 0.2))
-        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.1 + right_hip_offset
-        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.4 - right_hip_offset * 1.2
-        self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.0 + right_hip_offset * 0.5
-        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.1 + left_hip_offset
-        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.4 - left_hip_offset * 1.2
-        self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.0 + left_hip_offset * 0.5
+        ramp = float(np.clip((float(self.data.time) - float(self.walk_start_time)) / 1.0, 0.0, 1.0))
+        right_hip_offset *= ramp
+        left_hip_offset *= ramp
+
+        self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = 0.0
+        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.0 + right_hip_offset
+        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.2 - right_hip_offset * 1.0
+        self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.05 + right_hip_offset * 0.4
+        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.0 + left_hip_offset
+        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.2 - left_hip_offset * 1.0
+        self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.05 + left_hip_offset * 0.4
 
         # 关节目标低通滤波（原有逻辑）
         if self.enable_robust_optim:
@@ -908,6 +914,8 @@ class HumanoidStabilizer:
             idx = self.joint_name_to_idx[joint_name]
             joint_error = float(self.joint_targets[idx] - current_joints[idx])
             joint_error = max(-0.3, min(0.3, joint_error))
+            if joint_name == "abdomen_y":
+                joint_error += float(np.clip(torso_torque[1] * 0.01, -0.15, 0.15))
             torques[idx] = self.kp_waist * joint_error - self.kd_waist * current_vel[idx]
 
         # 腿部关节控制（新增：基于接触力的动态PD增益）
@@ -939,9 +947,9 @@ class HumanoidStabilizer:
                 kd = self.base_kd_hip * force_factor
                 if "y" in joint_name:
                     if "right" in joint_name:
-                        joint_error += torso_torque[1] * 0.02
+                        joint_error += torso_torque[1] * 0.03
                     else:
-                        joint_error += torso_torque[1] * 0.02
+                        joint_error += torso_torque[1] * 0.03
 
             elif "knee" in joint_name:
                 kp = self.base_kp_knee * force_factor
@@ -952,7 +960,7 @@ class HumanoidStabilizer:
                 kp = self.base_kp_ankle * force_factor
                 kd = self.base_kd_ankle * force_factor
                 if "y" in joint_name:
-                    joint_error += torso_torque[1] * 0.01
+                    joint_error += torso_torque[1] * 0.02
 
             # 原有接触判断逻辑（保留，与动态增益叠加）
             if ("left" in joint_name and self.foot_contact[1] == 0) or \


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->针对“ 一直往下倒（前倾摔） ”继续做了几处稳定性优化
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 站立复位更“软” ： _init_stable_pose() 里把站立目标从原来的“屈髋屈膝”改为 腿部关节全 0 的更中性姿态 ，减少一上来就前倾的趋势
2. 复位时直接把关节 qpos 设到目标 ：避免“刚 reset 后关节角是 0，但目标却是另一套角度”导致 PD 瞬间猛拉、身体前栽
3. 走路起步加 1 秒斜坡 ：进入 WALK 后前 1 秒逐步放大步态偏移，避免一切换就大幅摆腿把人甩到前面
4. 去掉行走时 abdomen_y 的“随速度前倾” ：之前这个可能会把身体持续压向前，现在行走时保持 abdomen_y = 0 ，俯仰交给平衡环来修
5. 加强俯仰纠正的力矩耦合 ：把俯仰纠正更明显地作用到 abdomen_y/hip_y/ankle_y ，提升“往前倒时拉回来”的能力
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1710" height="1113" alt="微信图片_20260426130249_383_2" src="https://github.com/user-attachments/assets/358aad61-7bf6-49f5-8194-b77ceb6aa954" />

