### PR TITLE
fix(mujoco_manrun): 解除姿态角裁剪并增加跌倒恢复锁，抑制重复W触发刷屏

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -164,9 +164,11 @@ class KeyboardInputHandler(threading.Thread):
         key = key.lower()
         if key == 'w':
             current_gait = self.stabilizer.gait_mode
-            self.stabilizer.set_state("WALK")
-            self.stabilizer.set_gait_mode(current_gait)
-            print(f"[行走] 速度:{self.stabilizer.walk_speed:.2f} | 转向:{self.stabilizer.turn_angle:.2f}")
+            if self.stabilizer.state != "WALK":
+                self.stabilizer.set_state("WALK")
+                self.stabilizer.set_gait_mode(current_gait)
+            if hasattr(self.stabilizer, "_should_log") and self.stabilizer._should_log("key_walk", 0.5):
+                print(f"[行走] 速度:{self.stabilizer.walk_speed:.2f} | 转向:{self.stabilizer.turn_angle:.2f}")
         elif key == 's':
             self.stabilizer.set_state("STOP")
             print("[停止]")
@@ -277,6 +279,7 @@ class HumanoidStabilizer:
         self._log_last = {}
         self._fall_cooldown_until = 0.0
         self._fall_count = 0
+        self._recovery_until = 0.0
         self._imu_euler_filt = np.zeros(3, dtype=np.float64)
         self._imu_angvel_filt = np.zeros(3, dtype=np.float64)
 
@@ -777,6 +780,8 @@ class HumanoidStabilizer:
     # 外部控制接口（原有逻辑完全保留）
     def set_state(self, state):
         if state in self.state_map.keys():
+            if state == "WALK" and float(self.data.time) < float(self._recovery_until):
+                return
             self.state = state
             if state == "WALK":
                 self.walk_start_time = None
@@ -813,7 +818,7 @@ class HumanoidStabilizer:
         quat = self.data.qpos[3:7].astype(np.float64).copy()
         euler = self._quat_to_euler_xyz(quat)
         euler = np.mod(euler + np.pi, 2 * np.pi) - np.pi
-        return np.clip(euler, -0.3, 0.3)
+        return euler
 
     # 原有接触检测方法（保留，用于关闭传感器模拟时的 fallback）
     def _detect_foot_contact(self):
@@ -1078,6 +1083,8 @@ class HumanoidStabilizer:
                         )
                         self.set_state("STAND")  # 跌倒后自动恢复站立
                         self._fall_cooldown_until = float(self.data.time) + 1.0
+                        self._recovery_until = float(self.data.time) + 2.0
+                        self.set_turn_angle(0.0)
         finally:
             keyboard_handler.running = False
             self.ros_handler.stop()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 取消 _get_root_euler() 的 ±0.3rad 裁剪 ：现在返回真实的 roll/pitch/yaw（仍做了 ±π 的环绕），控制器能感知更大的前倾并输出更强的纠正力矩
2. 键盘 w 打印节流 + 已是 WALK 不重复切换 ：避免 [行走] 刷屏、避免反复 set_state 导致状态抖动
3. 跌倒后加入 2 秒“恢复锁” ：跌倒切回 STAND 后，2 秒内禁止再次进入 WALK，并把转向归零，避免刚恢复就被重复 w 拉回走路
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1710" height="1113" alt="4937f5e2025edaa0c59b4228c3c7e18f" src="https://github.com/user-attachments/assets/e3554810-bc40-4dc7-b184-c543e15707c1" />
