### PR TITLE
添加多车道识别功能

### DIFF
--- a/src/lane_identification/.gitignore
+++ b/src/lane_identification/.gitignore
@@ -40,3 +40,8 @@ Thumbs.db
 *.png
 *.mp4
 *.avi
+
+# Test files
+test.py
+*_test.py
+tests/

--- a/src/lane_identification/software_package/lane_detector.py
+++ b/src/lane_identification/software_package/lane_detector.py
@@ -16,7 +16,7 @@ class LaneDetector:
         self.lane_history = deque(maxlen=5)
 
     def detect(self, image: np.ndarray, roi_mask: np.ndarray, light_condition: str = 'day') -> Dict[str, Any]:
-        """检测车道线"""
+        """检测车道线 - 支持多车道场景"""
         try:
             processed = self._preprocess_for_lanes(image, roi_mask, light_condition)
             edges = self._detect_edges(processed, light_condition)
@@ -27,19 +27,37 @@ class LaneDetector:
                 return self._create_empty_result()
 
             left_lines, right_lines = self._classify_and_filter(lines, image.shape[1])
-            left_lane = self._fit_lane_model(left_lines, image.shape)
-            right_lane = self._fit_lane_model(right_lines, image.shape)
+
+            # 新增：选择主车道和邻车道
+            primary_left, primary_right, neighbor_left, neighbor_right = \
+                self._select_primary_lanes(left_lines, right_lines, image.shape[1], image.shape[0])
+
+            # 使用主车道线进行拟合
+            left_lane = self._fit_lane_model(primary_left, image.shape)
+            right_lane = self._fit_lane_model(primary_right, image.shape)
 
             left_lane, right_lane = self._validate_lanes(left_lane, right_lane, image.shape)
             center_line = self._calculate_center_line(left_lane, right_lane, image.shape)
             future_path = self._predict_future_path(left_lane, right_lane, image.shape)
             detection_quality = self._calculate_detection_quality(left_lane, right_lane)
 
+            # 新增：计算车道统计信息
+            all_lines = left_lines + right_lines
+            lane_stats = self._calculate_lane_statistics(all_lines, image.shape)
+
             result = {
-                'left_lines': left_lines, 'right_lines': right_lines,
-                'left_lane': left_lane, 'right_lane': right_lane,
-                'center_line': center_line, 'future_path': future_path,
-                'detection_quality': detection_quality
+                'left_lines': left_lines,
+                'right_lines': right_lines,
+                'primary_left_lines': primary_left,
+                'primary_right_lines': primary_right,
+                'neighbor_left_lines': neighbor_left,
+                'neighbor_right_lines': neighbor_right,
+                'left_lane': left_lane,
+                'right_lane': right_lane,
+                'center_line': center_line,
+                'future_path': future_path,
+                'detection_quality': detection_quality,
+                'lane_statistics': lane_stats
             }
 
             result = self._apply_temporal_smoothing(result)
@@ -128,6 +146,71 @@ class LaneDetector:
                     })
         
         return left_lines, right_lines
+
+    def _select_primary_lanes(self, left_lines: List[Dict], right_lines: List[Dict],
+                              image_width: int, image_height: int) -> Tuple[List, List, List, List]:
+        """从多条候选线中选择主车道和邻车道
+
+        Returns:
+            primary_left: 主车道左边界线（最靠近中心的）
+            primary_right: 主车道右边界线（最靠近中心的）
+            neighbor_left: 左侧邻车道线列表
+            neighbor_right: 右侧邻车道线列表
+        """
+        if not left_lines and not right_lines:
+            return [], [], [], []
+
+        center_x = image_width / 2
+
+        # 按到中点的距离排序
+        left_lines_sorted = sorted(left_lines, key=lambda x: abs(x['midpoint'][0] - center_x))
+        right_lines_sorted = sorted(right_lines, key=lambda x: abs(x['midpoint'][0] - center_x))
+
+        # 选择最靠近中心的前2条作为主车道边界
+        primary_left = left_lines_sorted[:2] if len(left_lines_sorted) >= 2 else left_lines_sorted
+        primary_right = right_lines_sorted[:2] if len(right_lines_sorted) >= 2 else right_lines_sorted
+
+        # 其余的作为邻车道
+        neighbor_left = left_lines_sorted[2:] if len(left_lines_sorted) > 2 else []
+        neighbor_right = right_lines_sorted[2:] if len(right_lines_sorted) > 2 else []
+
+        return primary_left, primary_right, neighbor_left, neighbor_right
+
+    def _calculate_lane_statistics(self, all_lines: List[Dict], image_shape: Tuple[int, ...]) -> Dict:
+        """计算车道统计信息"""
+        height, width = image_shape[:2]
+
+        if not all_lines:
+            return {
+                'total_detected_lines': 0,
+                'estimated_lanes': 1,
+                'is_multi_lane': False,
+                'avg_lane_width': 0,
+                'lane_positions': []
+            }
+
+        # 按X坐标排序所有车道线的中点
+        midpoints = sorted([line['midpoint'][0] for line in all_lines])
+
+        # 估算车道数量（每2条线形成一个车道）
+        estimated_lanes = max(1, len(all_lines) // 2)
+
+        # 计算平均车道宽度
+        lane_widths = []
+        for i in range(len(midpoints) - 1):
+            width_diff = abs(midpoints[i + 1] - midpoints[i])
+            if width_diff > width * 0.05 and width_diff < width * 0.4:
+                lane_widths.append(width_diff)
+
+        avg_lane_width = np.mean(lane_widths) if lane_widths else 0
+
+        return {
+            'total_detected_lines': len(all_lines),
+            'estimated_lanes': estimated_lanes,
+            'is_multi_lane': estimated_lanes > 2,
+            'avg_lane_width': avg_lane_width,
+            'lane_positions': midpoints
+        }
     
     def _fit_lane_model(self, lines: List[Dict], image_shape: Tuple[int, ...]) -> Optional[Dict]:
         """拟合车道线模型"""
@@ -370,9 +453,20 @@ class LaneDetector:
         return {
             'left_lines': [],
             'right_lines': [],
+            'primary_left_lines': [],
+            'primary_right_lines': [],
+            'neighbor_left_lines': [],
+            'neighbor_right_lines': [],
             'left_lane': None,
             'right_lane': None,
             'center_line': None,
             'future_path': None,
-            'detection_quality': 0.0
+            'detection_quality': 0.0,
+            'lane_statistics': {
+                'total_detected_lines': 0,
+                'estimated_lanes': 1,
+                'is_multi_lane': False,
+                'avg_lane_width': 0,
+                'lane_positions': []
+            }
         }

--- a/src/lane_identification/software_package/visualizer.py
+++ b/src/lane_identification/software_package/visualizer.py
@@ -25,9 +25,14 @@ class Visualizer:
             'road_area': (0, 180, 0, 100),
             'road_boundary': (0, 255, 255, 200),
 
-            # 车道线
+            # 车道线 - 主车道（高亮）
             'left_lane': (255, 100, 100, 200),
             'right_lane': (100, 100, 255, 200),
+
+            # 邻车道（黄色）
+            'neighbor_lane': (255, 255, 0, 150),
+
+            # 中心线
             'center_line': (255, 255, 0, 180),
 
             # 路径预测
@@ -88,44 +93,46 @@ class Visualizer:
 
         # 转回 OpenCV 格式
         return cv2.cvtColor(np.array(img_pil), cv2.COLOR_RGB2BGR)
-    
-    def create_visualization(self, image: np.ndarray, 
-                           road_info: Dict[str, Any],
-                           lane_info: Dict[str, Any], 
-                           direction_info: Dict[str, Any],
-                           is_video: bool = False,
-                           frame_info: Dict[str, Any] = None) -> np.ndarray:
+
+    def create_visualization(self, image: np.ndarray,
+                             road_info: Dict[str, Any],
+                             lane_info: Dict[str, Any],
+                             direction_info: Dict[str, Any],
+                             is_video: bool = False,
+                             frame_info: Dict[str, Any] = None) -> np.ndarray:
         """创建可视化结果"""
         try:
-            # 创建副本
             visualization = image.copy()
-            
+
             # 1. 绘制道路区域
             if road_info.get('contour') is not None:
                 visualization = self._draw_road_area(visualization, road_info)
-            
+
             # 2. 绘制车道线
             visualization = self._draw_lanes(visualization, lane_info)
-            
+
             # 3. 绘制路径预测
             if lane_info.get('future_path'):
                 visualization = self._draw_future_path(visualization, lane_info['future_path'])
-            
+
             # 4. 绘制信息面板
             visualization = self._draw_info_panel(visualization, direction_info, lane_info, is_video, frame_info)
-            
+
             # 5. 绘制方向指示器
             visualization = self._draw_direction_indicator(visualization, direction_info)
-            
-            # 6. 应用全局效果
+
+            # 6. 绘制图例（新增）
+            visualization = self._draw_legend(visualization, lane_info)
+
+            # 7. 应用全局效果
             visualization = self._apply_global_effects(visualization)
-            
+
             return visualization
-            
+
         except Exception as e:
             print(f"可视化创建失败: {e}")
             return image
-    
+
     def _draw_road_area(self, image: np.ndarray, road_info: Dict[str, Any]) -> np.ndarray:
         """绘制道路区域"""
         contour = road_info['contour']
@@ -146,43 +153,68 @@ class Visualizer:
         cv2.addWeighted(road_layer, alpha, image, 1 - alpha, 0, image)
         
         return image
-    
+
     def _draw_lanes(self, image: np.ndarray, lane_info: Dict[str, Any]) -> np.ndarray:
-        """绘制车道线"""
+        """绘制车道线 - 支持多车道显示"""
         lane_layer = image.copy()
-        
-        # 绘制原始检测线段
-        for side, color_key in [('left_lines', 'left_lane'), ('right_lines', 'right_lane')]:
+
+        # 1. 绘制所有原始检测线段（浅色）
+        for side in ['left_lines', 'right_lines']:
             lines = lane_info.get(side, [])
-            color = self.colors[color_key]
-            
+
             for line in lines:
                 points = line.get('points', [])
                 if len(points) == 2:
-                    cv2.line(lane_layer, points[0], points[1], color[:3], 1, cv2.LINE_AA)
-        
-        # 绘制拟合的车道线
+                    cv2.line(lane_layer, points[0], points[1], (100, 100, 100), 1, cv2.LINE_AA)
+
+        # 2. 绘制邻车道线（黄色虚线）
+        for side in ['neighbor_left_lines', 'neighbor_right_lines']:
+            lines = lane_info.get(side, [])
+
+            for line in lines:
+                points = line.get('points', [])
+                if len(points) == 2:
+                    cv2.line(lane_layer, points[0], points[1],
+                             self.colors['neighbor_lane'][:3], 2, cv2.LINE_AA)
+
+        # 3. 绘制主车道边界线（加粗高亮）
+        primary_left_lines = lane_info.get('primary_left_lines', [])
+        primary_right_lines = lane_info.get('primary_right_lines', [])
+
+        for line in primary_left_lines:
+            points = line.get('points', [])
+            if len(points) == 2:
+                cv2.line(lane_layer, points[0], points[1],
+                         self.colors['left_lane'][:3], 3, cv2.LINE_AA)
+
+        for line in primary_right_lines:
+            points = line.get('points', [])
+            if len(points) == 2:
+                cv2.line(lane_layer, points[0], points[1],
+                         self.colors['right_lane'][:3], 3, cv2.LINE_AA)
+
+        # 4. 绘制拟合的主车道线
         for side, color_key in [('left_lane', 'left_lane'), ('right_lane', 'right_lane')]:
             lane = lane_info.get(side)
             if lane and 'points' in lane and len(lane['points']) == 2:
                 points = lane['points']
                 color = self.colors[color_key]
-                
+
                 confidence = lane.get('confidence', 0.5)
-                thickness = 2 + int(confidence * 4)
-                
+                thickness = 3 + int(confidence * 4)
+
                 cv2.line(lane_layer, points[0], points[1], color[:3], thickness, cv2.LINE_AA)
-        
-        # 绘制中心线
+
+        # 5. 绘制中心线
         center_line = lane_info.get('center_line')
         if center_line and 'points' in center_line and len(center_line['points']) == 2:
             points = center_line['points']
             color = self.colors['center_line']
             cv2.line(lane_layer, points[0], points[1], color[:3], 2, cv2.LINE_AA)
-        
+
         # 混合车道线图层
         cv2.addWeighted(lane_layer, 0.7, image, 0.3, 0, image)
-        
+
         return image
     
     def _draw_future_path(self, image: np.ndarray, future_path: Dict[str, Any]) -> np.ndarray:
@@ -214,7 +246,7 @@ class Visualizer:
         height, width = image.shape[:2]
 
         # 创建半透明背景
-        panel_height = 120
+        panel_height = 140
         overlay = image.copy()
         cv2.rectangle(overlay, (0, 0), (width, panel_height), (0, 0, 0, 180), -1)
         cv2.addWeighted(overlay, 0.7, image, 0.3, 0, image)
@@ -239,7 +271,21 @@ class Visualizer:
         quality_text = f"检测质量: {quality:.1%}"
         image = self._put_chinese_text(image, quality_text, (20, 75), self.colors['text_secondary'], 'small')
 
-        # 4. 视频信息
+        # 4. 车道统计信息（新增）
+        lane_stats = lane_info.get('lane_statistics', {})
+        if lane_stats:
+            total_lines = lane_stats.get('total_detected_lines', 0)
+            estimated_lanes = lane_stats.get('estimated_lanes', 1)
+            is_multi = lane_stats.get('is_multi_lane', False)
+
+            stats_text = f"检测到{total_lines}条线 | 估算{estimated_lanes}车道"
+            if is_multi:
+                stats_text += " [多车道]"
+
+            image = self._put_chinese_text(image, stats_text, (20, 100),
+                                           self.colors['text_secondary'], 'small')
+
+        # 5. 视频信息
         if is_video and frame_info:
             fps_text = f"FPS: {frame_info.get('fps', 0):.1f}"
             frame_text = f"帧: {frame_info.get('frame_number', 0)}"
@@ -249,7 +295,7 @@ class Visualizer:
             image = self._put_chinese_text(image, frame_text, (width - 200, 40),
                                            self.colors['text_primary'], 'small')
 
-        # 5. 概率分布
+        # 6. 概率分布
         if 'probabilities' in direction_info:
             probabilities = direction_info['probabilities']
             start_x = width - 200
@@ -345,7 +391,50 @@ class Visualizer:
             return self.colors['confidence_low']
         else:
             return self.colors['confidence_very_low']
-    
+
+    def _draw_legend(self, image: np.ndarray, lane_info: Dict[str, Any]) -> np.ndarray:
+        """绘制图例说明"""
+        lane_stats = lane_info.get('lane_statistics', {})
+        if not lane_stats or lane_stats.get('total_detected_lines', 0) < 3:
+            return image
+
+        height, width = image.shape[:2]
+
+        # 创建图例背景
+        legend_width = 180
+        legend_height = 90
+        overlay = image.copy()
+        cv2.rectangle(overlay, (width - legend_width - 10, height - legend_height - 10),
+                      (width - 10, height - 10), (0, 0, 0, 200), -1)
+        cv2.addWeighted(overlay, 0.6, image, 0.4, 0, image)
+
+        # 图例文字
+        legend_start_x = width - legend_width
+        legend_start_y = height - legend_height
+
+        # 主车道
+        cv2.line(image, (legend_start_x + 10, legend_start_y + 25),
+                 (legend_start_x + 40, legend_start_y + 25), (255, 100, 100), 3)
+        image = self._put_chinese_text(image, "主车道",
+                                       (legend_start_x + 50, legend_start_y + 15),
+                                       self.colors['text_primary'], 'small')
+
+        # 邻车道
+        cv2.line(image, (legend_start_x + 10, legend_start_y + 50),
+                 (legend_start_x + 40, legend_start_y + 50), (255, 255, 0), 2)
+        image = self._put_chinese_text(image, "邻车道",
+                                       (legend_start_x + 50, legend_start_y + 40),
+                                       self.colors['text_primary'], 'small')
+
+        # 中心线
+        cv2.line(image, (legend_start_x + 10, legend_start_y + 75),
+                 (legend_start_x + 40, legend_start_y + 75), (255, 255, 0), 2)
+        image = self._put_chinese_text(image, "中心线",
+                                       (legend_start_x + 50, legend_start_y + 65),
+                                       self.colors['text_primary'], 'small')
+
+        return image
+
     def _apply_global_effects(self, image: np.ndarray) -> np.ndarray:
         """应用全局效果"""
         # 轻微锐化


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
- 实现基于距离的车道分组功能，支持多车道场景下的主车道与邻车道区分
- 增强可视化显示，用不同颜色标识主车道和邻车道
- 添加车道统计信息，实时显示检测到的车道数量
- 测试可通过，但是真实场景置信度低，还需要完善

## 修改的详细描述
### 1. 核心功能改进（lane_detector.py）
- **新增 `_select_primary_lanes()` 方法**：根据车道线到图像中心的距离，自动选择最靠近中心的2条线作为主车道边界，其余识别为邻车道
- **新增 `_calculate_lane_statistics()` 方法**：计算并返回车道统计信息，包括总检测线数、估算车道数、是否多车道、平均车道宽度等
- **修改 `detect()` 方法**：返回结果中增加 `primary_left_lines`、`primary_right_lines`、`neighbor_left_lines`、`neighbor_right_lines` 和 `lane_statistics` 字段
- **更新 `_create_empty_result()` 方法**：确保空结果包含所有新字段，保持数据结构一致性

### 2. 可视化增强（visualizer.py）
- **新增邻车道颜色配置**：使用黄色 `(255, 255, 0)` 标识邻车道，与主车道的红/蓝色形成对比
- **改进 `_draw_lanes()` 方法**：
  - 灰色细线：绘制所有原始检测线段
  - 黄色细线：绘制邻车道边界
  - 红/蓝色粗线（3px）：高亮显示主车道边界
  - 加粗拟合线：根据置信度动态调整线宽
- **新增 `_draw_legend()` 方法**：在右下角绘制图例，说明不同颜色线条的含义（仅在多车道场景显示）
- **改进 `_draw_info_panel()` 方法**：在信息面板底部显示"检测到X条线 | 估算Y车道 [多车道]"的统计信息
- **更新 `create_visualization()` 方法**：调用新的图例绘制函数

<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：Windows 25H2
2. Python版本：Python 3.9
3. OpenCV版本：4.8.0.74
4. NumPy版本：1.24.3
5. 测试内容：模拟6条车道线（左右各3条），验证主车道选择、邻车道识别和车道统计功能
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
<img width="706" height="894" alt="2026-04-27_15-52-28" src="https://github.com/user-attachments/assets/90f9db9c-f65f-427f-bac0-7640e05a6636" />

