### PR TITLE
fix(mujoco_manrun): 恢复半蹲基姿态并修正俯仰耦合符号，状态输出改用true_euler减少误判

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -529,16 +529,16 @@ class HumanoidStabilizer:
         # 右腿关节
         self.joint_targets[self.joint_name_to_idx["hip_x_right"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["hip_z_right"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["knee_right"]] = 0.0
+        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.1
+        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.4
         self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_x_right"]] = 0.0
 
         # 左腿关节
         self.joint_targets[self.joint_name_to_idx["hip_x_left"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["hip_z_left"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["knee_left"]] = 0.0
+        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.1
+        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.4
         self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.0
         self.joint_targets[self.joint_name_to_idx["ankle_x_left"]] = 0.0
 
@@ -743,19 +743,18 @@ class HumanoidStabilizer:
         )
 
         # 5. 更新关节目标（原有逻辑保留）
-        if self.gait_mode != "STEP_IN_PLACE":
-            self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = float(np.clip(0.12 * speed_factor, -0.2, 0.2))
         ramp = float(np.clip((float(self.data.time) - float(self.walk_start_time)) / 1.0, 0.0, 1.0))
         right_hip_offset *= ramp
         left_hip_offset *= ramp
 
-        self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = 0.0
-        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.0 + right_hip_offset
-        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.2 - right_hip_offset * 1.0
-        self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.05 + right_hip_offset * 0.4
-        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.0 + left_hip_offset
-        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.2 - left_hip_offset * 1.0
-        self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.05 + left_hip_offset * 0.4
+        if self.gait_mode != "STEP_IN_PLACE":
+            self.joint_targets[self.joint_name_to_idx["abdomen_y"]] = float(np.clip(-0.06 * speed_factor, -0.12, 0.0))
+        self.joint_targets[self.joint_name_to_idx["hip_y_right"]] = 0.1 + right_hip_offset
+        self.joint_targets[self.joint_name_to_idx["knee_right"]] = -0.4 - right_hip_offset * 1.2
+        self.joint_targets[self.joint_name_to_idx["ankle_y_right"]] = 0.0 + right_hip_offset * 0.5
+        self.joint_targets[self.joint_name_to_idx["hip_y_left"]] = 0.1 + left_hip_offset
+        self.joint_targets[self.joint_name_to_idx["knee_left"]] = -0.4 - left_hip_offset * 1.2
+        self.joint_targets[self.joint_name_to_idx["ankle_y_left"]] = 0.0 + left_hip_offset * 0.5
 
         # 关节目标低通滤波（原有逻辑）
         if self.enable_robust_optim:
@@ -920,7 +919,7 @@ class HumanoidStabilizer:
             joint_error = float(self.joint_targets[idx] - current_joints[idx])
             joint_error = max(-0.3, min(0.3, joint_error))
             if joint_name == "abdomen_y":
-                joint_error += float(np.clip(torso_torque[1] * 0.01, -0.15, 0.15))
+                joint_error -= float(np.clip(torso_torque[1] * 0.008, -0.15, 0.15))
             torques[idx] = self.kp_waist * joint_error - self.kd_waist * current_vel[idx]
 
         # 腿部关节控制（新增：基于接触力的动态PD增益）
@@ -952,9 +951,9 @@ class HumanoidStabilizer:
                 kd = self.base_kd_hip * force_factor
                 if "y" in joint_name:
                     if "right" in joint_name:
-                        joint_error += torso_torque[1] * 0.03
+                        joint_error -= torso_torque[1] * 0.02
                     else:
-                        joint_error += torso_torque[1] * 0.03
+                        joint_error -= torso_torque[1] * 0.02
 
             elif "knee" in joint_name:
                 kp = self.base_kp_knee * force_factor
@@ -965,7 +964,7 @@ class HumanoidStabilizer:
                 kp = self.base_kp_ankle * force_factor
                 kd = self.base_kd_ankle * force_factor
                 if "y" in joint_name:
-                    joint_error += torso_torque[1] * 0.02
+                    joint_error -= torso_torque[1] * 0.015
 
             # 原有接触判断逻辑（保留，与动态增益叠加）
             if ("left" in joint_name and self.foot_contact[1] == 0) or \
@@ -1055,8 +1054,11 @@ class HumanoidStabilizer:
                     # 状态监测（新增步态信息）
                     if self._should_log("status", 2.0):
                         com = self.data.subtree_com[0]
-                        euler = self.current_sensor_data["imu"][
-                            "euler"] if self.current_sensor_data else self._get_root_euler()
+                        if self.current_sensor_data:
+                            imu_data = self.current_sensor_data["imu"]
+                            euler = imu_data.get("true_euler", imu_data.get("euler"))
+                        else:
+                            euler = self._get_root_euler()
                         print(
                             f"时间:{self.data.time:.1f}s | 重心(x/z):{com[0]:.3f}/{com[2]:.3f}m | "
                             f"姿态(roll/pitch):{euler[0]:.3f}/{euler[1]:.3f}rad | 脚接触:{self.foot_contact} | "
@@ -1082,7 +1084,7 @@ class HumanoidStabilizer:
                             f"最大倾角:{max(abs(euler_for_fall[0]), abs(euler_for_fall[1])):.3f}rad | 当前步态:{self.gait_mode}"
                         )
                         self.set_state("STAND")  # 跌倒后自动恢复站立
-                        self._fall_cooldown_until = float(self.data.time) + 1.0
+                        self._fall_cooldown_until = float(self.data.time) + 2.0
                         self._recovery_until = float(self.data.time) + 2.0
                         self.set_turn_angle(0.0)
         finally:


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 恢复更稳的“半蹲站立基姿态” ：把站立目标从腿部全 0 改回 hip_y=0.1, knee=-0.4 （更接近原先稳定姿态），并仍然在复位时把 qpos 直接对齐到目标，避免 PD 猛拉
2. 行走目标回到半蹲基线 + 起步斜坡保留 ：走路时的 hip/knee/ankle 目标以 0.1/-0.4/0.0 为基线再叠加 CPG 偏移，避免腿过直导致前栽
3. 抑制“向前倒”的耦合符号（关键） ：把俯仰纠正 torso_torque[1] 作用到 abdomen_y / hip_y / ankle_y 的方向改为相反（从 += 改为 -= 并略调系数），避免出现正反馈把自己越推越倒
4. 状态打印改用 true_euler ：现在状态行显示的 roll/pitch 优先用 true_euler ，不再被 IMU 的 ±π/2 限幅误导
5. 跌倒后冷却时间加长 ： _fall_cooldown_until 从 1.0s 增到 2.0s，给复位后的稳定过程更多时间
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1709" height="1112" alt="e73865e72cabda2b72247339f6c1d697" src="https://github.com/user-attachments/assets/abc658f9-5673-4227-9984-64514d568df0" />
