### PR TITLE
fix(mujoco_manrun): 修正踝关节俯仰耦合方向并用true_imu控制，提升站立恢复稳定性

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -872,8 +872,12 @@ class HumanoidStabilizer:
         torques = np.zeros(self.num_joints, dtype=np.float64)
 
         # 躯干姿态控制（改用传感器IMU数据）
-        root_euler = imu["euler"]  # 带噪声的欧拉角
-        root_vel = imu["ang_vel"]  # 带噪声的角速度
+        if self.enable_sensor_simulation:
+            root_euler = imu.get("true_euler", imu["euler"])
+            root_vel = imu.get("true_ang_vel", imu["ang_vel"])
+        else:
+            root_euler = imu["euler"]
+            root_vel = imu["ang_vel"]
         root_vel = np.clip(root_vel, -3.0, 3.0)
 
         imu_alpha = 0.2
@@ -936,7 +940,7 @@ class HumanoidStabilizer:
             joint_error = max(-0.3, min(0.3, joint_error))
 
             # 动态PD增益 - 接触力越小，增益越低（避免打滑）
-            if self.enable_robust_optim:
+            if self.enable_robust_optim and self.state == "WALK":
                 # 计算接触力归一化系数（0~1）
                 if "right" in joint_name:
                     force_factor = np.clip(self.right_foot_force / self._force_factor_norm, 0.4, 1.1)
@@ -959,18 +963,20 @@ class HumanoidStabilizer:
                 kp = self.base_kp_knee * force_factor
                 kd = self.base_kd_knee * force_factor
                 joint_error += com_compensation[2] * 0.05
+                joint_error += torso_torque[1] * 0.01
 
             elif "ankle" in joint_name:
                 kp = self.base_kp_ankle * force_factor
                 kd = self.base_kd_ankle * force_factor
                 if "y" in joint_name:
-                    joint_error -= torso_torque[1] * 0.015
+                    joint_error += torso_torque[1] * 0.015
 
             # 原有接触判断逻辑（保留，与动态增益叠加）
-            if ("left" in joint_name and self.foot_contact[1] == 0) or \
-                    ("right" in joint_name and self.foot_contact[0] == 0):
-                kp *= 0.8
-                kd *= 0.9
+            if self.state == "WALK":
+                if ("left" in joint_name and self.foot_contact[1] == 0) or \
+                        ("right" in joint_name and self.foot_contact[0] == 0):
+                    kp *= 0.8
+                    kd *= 0.9
 
             torques[idx] = kp * joint_error - kd * current_vel[idx]
 


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. ankle_y 俯仰耦合改回正确方向 ： ankle_y 从 joint_error -= torso_torque[1]*k 改为 += ，让“向前倒时（需要抬回来）”产生正确的踝关节纠正
2. knee 增加少量俯仰耦合 ：因为实验显示 knee 正向也能把身体抬回来，给 knee 加一个很小的 + torso_torque[1]*0.01
3. STAND 时不再被“脚未接触”降增益拖死 ：接触为 0 的降增益只在 WALK 生效，避免刚复位/延迟噪声导致 STAND 增益被压低而站不住
4. 另外：开启传感器模拟时， 控制用 true_euler/true_ang_vel （避免 noisy_euler 被量程裁到 ±π/2 导致控制失真），显示仍可用模拟值
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1709" height="1113" alt="84afadc462c97128a6b4d90d2ed74a3b" src="https://github.com/user-attachments/assets/3f5d8a50-51f5-4100-95fe-352030183f63" />
