### PR TITLE
fix(mujoco_manrun): 修正关节索引与控制映射，增强初始落地与恢复稳定性

### DIFF
--- a/src/mujoco_manrun/main.py
+++ b/src/mujoco_manrun/main.py
@@ -346,6 +346,10 @@ class HumanoidStabilizer:
         self._force_factor_norm = float(max(1.0, 0.5 * self.weight))
         self.com_safety_threshold = 0.6  # 重心z轴安全阈值（新增）
         self.speed_reduction_factor = 0.5  # 重心过低时的降速系数（新增）
+        self._support_body_id = int(mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "pelvis"))
+        if self._support_body_id < 0:
+            self._support_body_id = 0
+        self._support_until = 0.0
 
         self._left_foot_geom_ids = {
             mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "foot1_left"),
@@ -569,6 +573,22 @@ class HumanoidStabilizer:
 
         self.data.qpos[self._qpos_adr] = self.joint_targets.astype(np.float64)
         mujoco.mj_forward(self.model, self.data)
+        target_clearance = 0.002
+        min_bottom_z = None
+        foot_geom_ids = list(self._left_foot_geom_ids | self._right_foot_geom_ids)
+        for gid in foot_geom_ids:
+            if gid < 0:
+                continue
+            radius = float(self.model.geom_size[gid, 0])
+            z = float(self.data.geom_xpos[gid, 2]) - radius
+            if min_bottom_z is None or z < min_bottom_z:
+                min_bottom_z = z
+        if min_bottom_z is not None:
+            dz = (min_bottom_z - target_clearance)
+            if abs(dz) > 1e-6:
+                self.data.qpos[2] -= dz
+                mujoco.mj_forward(self.model, self.data)
+        self._support_until = float(self.data.time) + 3.0
 
     # ===================== 传感器模拟相关方法（原有新增逻辑保留） =====================
     def _simulate_imu_data(self):
@@ -916,6 +936,14 @@ class HumanoidStabilizer:
         torso_torque = np.array([roll_torque, pitch_torque, yaw_torque])
         torso_torque = np.clip(torso_torque, -30.0, 30.0)
 
+        self.data.xfrc_applied[self._support_body_id, :] = 0.0
+        now_t = float(self.data.time)
+        if now_t < float(self._support_until):
+            scale = float(np.clip((float(self._support_until) - now_t) / 3.0, 0.0, 1.0))
+            self.data.xfrc_applied[self._support_body_id, 2] = self.weight * 0.9 * scale
+            self.data.xfrc_applied[self._support_body_id, 3] = (-80.0 * self._imu_euler_filt[0] - 20.0 * self._imu_angvel_filt[0]) * scale
+            self.data.xfrc_applied[self._support_body_id, 4] = (-80.0 * self._imu_euler_filt[1] - 20.0 * self._imu_angvel_filt[1]) * scale
+
         # 重心补偿（原有逻辑完全保留）
         com = self.data.subtree_com[0].astype(np.float64).copy()
         com_error = self.com_target - com
@@ -1056,6 +1084,7 @@ class HumanoidStabilizer:
                 print(f"默认步态模式：{self.gait_mode}\n")
 
                 # 初始落地阶段（原有逻辑保留）
+                self._support_until = max(float(self._support_until), float(self.data.time) + float(self.init_wait_time))
                 start_time = time.time()
                 while time.time() - start_time < self.init_wait_time:
                     elapsed = time.time() - start_time


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 将关节状态读写从固定切片改为按关节名映射的 qposadr/dofadr ，避免关节顺序不一致导致的读写错位与开局发散。
2. 将“关节力矩”正确映射到 MuJoCo actuator ctrl （按 actuator gear 与 ctrlrange 归一化并限幅），避免 ctrl 被裁剪饱和导致无法行走/动作异常。
3. 打印节流：用时间戳节流替代 % 窗口判断，减少终端刷屏（含键盘 W、ROS /cmd_vel、状态输出）。
4. ROS /cmd_vel 支持真正停止： linear.x 很小或为 0 时进入 STOP 并清零转向，避免速度下限卡住。
5. 传感器与姿态控制稳健性：IMU 一阶滤波；控制优先使用 true_euler/true_ang_vel （模拟模式下）降低量程裁剪带来的控制失真；状态打印也优先展示 true_euler。
6. 足底力阈值与动态增益更合理：接触阈值按体重自适应；动态增益归一化按 weight 标定；仅在 WALK 时应用“未接触降增益”以免站立阶段被压低。
7. 初始落地稳定增强：落地阶段力矩更快爬升并带起始助力；复位后对齐脚底与地面小间隙；增加 pelvis 短时支撑力/扶正力矩并自动衰减，降低“开局秒摔/复位连摔”概率。
8. 跌倒恢复流程优化：增加冷却与恢复锁，避免反复触发跌倒与状态抖动。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
<img width="1709" height="1112" alt="4291015acb37f26a12a199594b02fc69" src="https://github.com/user-attachments/assets/9c893ccd-31e5-417e-9af1-ae19af7cfc56" />
