### PR TITLE
删除src/button_control_vehicle/main.py中服务响应中不存在的 success 字段赋值语句 response.success = False

### DIFF
--- a/src/button_control_vehicle/main.py
+++ b/src/button_control_vehicle/main.py
@@ -143,7 +143,7 @@ class GlobalPlannerNode(Node):
         # 新增：检查CARLA连接状态
         if not self.carla_connected or not self.map:
             self.get_logger().error("CARLA连接未建立或地图未初始化，无法规划路径")
-            response.success = False  # 假设服务定义中有success字段
+        
             return response
 
         try:


### PR DESCRIPTION
删除服务响应中不存在的 success 字段赋值语句 response.success = False 该字段未在 PlanGlobalPath 服务定义中声明，会导致运行时报错
仅做最小化修改，不影响其他功能

<!-- 感谢提交 pull request! -->


修改概述:    修复全局路径规划节点服务回调中的错误字段赋值问题，确保节点正常运行

## 修改的详细描述
删除服务响应中不存在的 success 字段赋值语句 response.success = False
该字段未在 PlanGlobalPath 服务定义中声明，会导致运行时报错
仅做最小化修改，不影响其他功能

## 经过了什么样的测试?
启动路径规划服务，正常调用并返回路径
## 运行效果
节点启动无报错
路径规划服务可正常调用
功能与修改前保持一致
