### PR TITLE
Fix indentation for context manager methods in recorder.py

### DIFF
--- a/src/active_lane_keeping_assistant/recorder.py
+++ b/src/active_lane_keeping_assistant/recorder.py
@@ -62,11 +62,11 @@ class Recorder():
             raise Exception('No video initialized.')
         self.video.release()
 
-        def __enter__(self):
-            """Context manager entry point"""
-            return self
+    def __enter__(self):
+        """Context manager entry point"""
+        return self
 
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            """Context manager exit point - ensures video is closed"""
-            if self.video is not None:
-                self.close_recording()
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit point - ensures video is closed"""
+        if self.video is not None:
+            self.close_recording()


### PR DESCRIPTION
The __enter__ and __exit__ methods were incorrectly indented inside the close_recording method, making them local functions instead of class methods.

- Fixed indentation to make __enter__ and __exit__ proper class methods
- This enables the Recorder class to be used as a context manager
- No functional changes to the code logic

<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述: 修复上下文管理器方法的缩进错误，使Recorder类支持with语句

## 修改的详细描述
1. 修复了 `src/active_lane_keeping_assistant/recorder.py` 文件中 `__enter__` 和 `__exit__` 方法的缩进错误
2. 将这两个方法从 `close_recording` 方法内部移出，使其成为 `Recorder` 类的正确实例方法
3. 修复后 `Recorder` 类可以正确作为上下文管理器使用（支持 `with` 语句）
4. 保持原有逻辑完全不变，仅修改缩进格式

<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：Windows 10 Pro
2. Python版本：Python 3.12
3. 静态代码分析：通过Python语法检查和IDE代码审查验证缩进正确性
4. 代码审查：确认方法签名和逻辑未发生任何变化

<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
这是一个纯粹的代码结构修复，不涉及运行效果变更。修复后 `Recorder` 类支持上下文管理器模式，可以使用 `with` 语句自动管理资源：

```python
# 修复后可以这样使用：
with Recorder() as rec:
    rec.init_new_video("test")
    # 添加视频帧...
    # 退出时自动调用close_recording()
