### PR TITLE
Add type hints and improve docstring in box_utils.py

### DIFF
--- a/src/2d_tracking/utils/box_utils.py
+++ b/src/2d_tracking/utils/box_utils.py
@@ -1,10 +1,24 @@
 import cv2
 import numpy as np
 
-def draw_bounding_boxes(image, boxes, labels, class_names, ids):
-    '''
-    boxes: (x_min, y_min, x_max, y_max)
-    '''
+def draw_bounding_boxes(image: np.ndarray,
+                       boxes: np.ndarray,
+                       labels: np.ndarray,
+                       class_names: list[str],
+                       ids: np.ndarray) -> np.ndarray:
+    """Draw bounding boxes with labels on an image.
+
+    Args:
+        image: Input image as numpy array (H, W, C).
+        boxes: Bounding boxes in format (x_min, y_min, x_max, y_max).
+            Shape: (N, 4).
+        labels: Class indices for each box. Shape: (N,).
+        class_names: List of class names indexed by label.
+        ids: Tracking IDs for each box. Shape: (N,).
+
+    Returns:
+        Image with drawn bounding boxes and labels.
+    """
     if not hasattr(draw_bounding_boxes, "colours"):
         draw_bounding_boxes.colours = np.random.randint(0, 256, size=(32, 3))
 
@@ -15,19 +29,22 @@ def draw_bounding_boxes(image, boxes, labels, class_names, ids):
     for i in range(boxes.shape[0]):
         box = boxes[i]
         label = f"{class_names[labels[i]]}: {int(ids[i])}"
-        # print(label)
+
+        # Get color for this tracking ID
+        color = tuple([int(c) for c in draw_bounding_boxes.colours[int(ids[i]) % 32, :]])
 
         # Draw bounding boxes
-        cv2.rectangle(  image, 
-                        (int(box[0].item()), int(box[1].item())), (int(box[2].item()), int(box[3].item())), 
-                        tuple([int(c) for c in draw_bounding_boxes.colours[int(ids[i]) % 32, :]]), 
-                        4)
+        cv2.rectangle(image,
+                     (int(box[0].item()), int(box[1].item())),
+                     (int(box[2].item()), int(box[3].item())),
+                     color,
+                     4)
 
         # Draw labels
         cv2.putText(image, label,
-                    (int(box[0]+20), int(box[1]+40)),
-                    cv2.FONT_HERSHEY_SIMPLEX,
-                    1,  # font scale
-                    tuple([int(c) for c in draw_bounding_boxes.colours[int(ids[i]) % 32, :]]),
-                    2)  # line type
+                   (int(box[0]+20), int(box[1]+40)),
+                   cv2.FONT_HERSHEY_SIMPLEX,
+                   1,  # font scale
+                   color,
+                   2)  # line type
     return image


### PR DESCRIPTION
Enhanced the draw_bounding_boxes function with:
- Complete type hints for all parameters and return value
- Improved docstring in Google style format
- Extracted repeated color calculation code into a variable
- Better code formatting for readability

<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述: 添加类型提示和改进文档字符串，提高代码可读性和可维护性

## 修改的详细描述
1. 为 `draw_bounding_boxes` 函数添加完整的类型提示：
   - `image: np.ndarray` - 输入图像
   - `boxes: np.ndarray` - 边界框数组
   - `labels: np.ndarray` - 类别标签
   - `class_names: list[str]` - 类别名称列表
   - `ids: np.ndarray` - 跟踪ID
   - 返回值: `np.ndarray` - 绘制了边界框的图像

2. 改进文档字符串为 Google 风格格式：
   - 添加详细的参数说明
   - 添加返回值说明
   - 提高文档的规范性和可读性

3. 代码优化：
   - 提取重复的颜色计算为 `color` 变量
   - 改进代码格式，提高可读性
   - 移除无用的注释代码

<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. 操作系统：Windows 10 Pro
2. Python版本：Python 3.12
3. 类型检查：使用mypy进行静态类型检查
4. 代码格式：遵循PEP 8规范

<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
这是一个纯粹的代码质量改进，不涉及运行效果变更。添加类型提示后：
- IDE 可以提供更好的代码补全和类型检查
- 便于静态分析工具检测潜在问题
- 提高代码可读性和可维护性
- 方便其他开发者理解函数接口

**修改前后对比：**

```python
# 修改前（无类型提示）：
def draw_bounding_boxes(image, boxes, labels, class_names, ids):
    '''
    boxes: (x_min, y_min, x_max, y_max)
    '''

# 修改后（完整类型提示）：
def draw_bounding_boxes(image: np.ndarray,
                       boxes: np.ndarray,
                       labels: np.ndarray,
                       class_names: list[str],
                       ids: np.ndarray) -> np.ndarray:
    """Draw bounding boxes with labels on an image.

    Args:
        image: Input image as numpy array (H, W, C).
        boxes: Bounding boxes in format (x_min, y_min, x_max, y_max).
            Shape: (N, 4).
        labels: Class indices for each box. Shape: (N,).
        class_names: List of class names indexed by label.
        ids: Tracking IDs for each box. Shape: (N,).

    Returns:
        Image with drawn bounding boxes and labels.
    """
