### PR TITLE
修复 src/car_racing/scripts/car_racing_node.py代码中Python 路径硬编码问题

### DIFF
--- a/src/car_racing/scripts/car_racing_node.py
+++ b/src/car_racing/scripts/car_racing_node.py
@@ -1,9 +1,10 @@
 import rospy
 import sys
+import os
 from std_msgs.msg import Float32, String
 
 # 导入同功能包内的你的原代码（不用跨目录，ROS封装的核心）
-sys.path.append("/home/ros-industrial/catkin_ws/src/car_racing_ros/your_python_code")
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../your_python_code"))
 
 from dqn_model.DQN_model import Agent as DQNAgent
 from double_dqn_model.double_dqn import DoubleDQNAgent as DDQNAgent


### PR DESCRIPTION

<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:   
修复src/car_racing/scripts/car_racing_node.py代码中 Python 路径硬编码问题，改为动态相对路径，提升代码可移植性。解决代码 换机器就跑不了的核心问题，其余所有逻辑、变量、发布器都保持原样。

## 修改的详细描述
1、将原固定绝对路径
/home/ros-industrial/catkin_ws/src/car_racing_ros/your_python_code改为基于当前脚本位置自动拼接的动态相对路径。
2、新增os模块导入，配合路径动态解析。
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
window11
python3.12
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
本地编译运行正常，模型导入、评估、话题发布功能均不受影响。
更换工作空间路径后仍可正常运行，不再依赖固定用户名和绝对路径。
