### PR TITLE
更新 MuJoCo 的下载命令，改用 Invoke-WebReques

### DIFF
--- a/run_mujoco.bat
+++ b/run_mujoco.bat
@@ -33,7 +33,7 @@ REM 检查是否需要下载
 if not exist "%MUJOCO_ZIP%" (
     echo [INFO] Downloading MuJoCo %MUJOCO_VERSION%...
     echo [INFO] URL: %MUJOCO_REPO%
-    powershell -Command "(New-Object System.Net.WebClient).DownloadFile('%MUJOCO_REPO%', '%MUJOCO_ZIP%')"
+    powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%MUJOCO_REPO%' -OutFile '%MUJOCO_ZIP%' -UseBasicParsing"
     if !errorlevel! neq 0 (
         echo [ERROR] Download failed! Please check network connection.
         exit /b 1


### PR DESCRIPTION

<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:    优化MuJoCo下载命令，解决Windows环境下因TLS协议兼容问题导致的下载失败。

## 修改的详细描述
1. 将原基于System.Net.WebClient的下载命令，替换为Invoke-WebRequest并强制启用TLS1.2；
2. 新增UseBasicParsing参数，避免依赖IE组件，提升无GUI环境兼容性；
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
：Windows 11
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
下载成功率100%，解压、运行MuJoCo功能正常
