### PR TITLE
优化机械臂大幅弯曲动作的PD控制稳定性，新增力矩限幅避免关节抖动

### DIFF
--- a/src/robotic_arm_gripping/main_mouse_control.py
+++ b/src/robotic_arm_gripping/main_mouse_control.py
@@ -65,11 +65,12 @@ def main():
             shoulder_error = shoulder_target - data.qpos[shoulder_joint_id]
             shoulder_vel = data.qvel[shoulder_joint_id]
             data.ctrl[shoulder_act_id] = kp * shoulder_error - kd * shoulder_vel
-
+            data.ctrl[shoulder_act_id] = np.clip(data.ctrl[shoulder_act_id], -500, 500) 
             # 肘关节控制
             elbow_error = elbow_target - data.qpos[elbow_joint_id]
             elbow_vel = data.qvel[elbow_joint_id]
             data.ctrl[elbow_act_id] = kp * elbow_error - kd * elbow_vel
+            data.ctrl[elbow_act_id] = np.clip(data.ctrl[elbow_act_id], -800, 800)
 
             # 夹爪保持张开状态
             data.ctrl[model.actuator("left").id] = 0.0


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:    优化机械臂大幅弯曲动作的PD控制稳定性，新增力矩限幅避免关节抖动

## 修改的详细描述
1. 对肩关节/肘关节的PD控制输出力矩新增np.clip限幅：
   - 肩关节力矩限制在±500
   - 肘关节力矩限制在±800
2. 限幅参数适配现有高PD增益（kp=1000），避免大幅弯曲时力矩过载导致的抖动；

<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
测试环境：MuJoCo  + Python 
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
无功能破坏性变更，仅提升动作控制的稳定性与平滑性
