### PR TITLE
调整相机视角pos参数，优化仿真展示效果

### DIFF
--- a/src/mujoco01/humanoid.xml
+++ b/src/mujoco01/humanoid.xml
@@ -105,14 +105,15 @@
     <light name="top" pos="0 0 2" mode="trackcom"/>
     <body name="torso" pos="0 0 1.282" childclass="body">
       <site name="torso_site" pos="0 0 0" size="0.01"/> <!-- 传感器用 -->
-      <camera name="back" pos="-3 0 1" xyaxes="0 -1 0 1 0 2" mode="trackcom"/>
-      <camera name="side" pos="0 -3 1" xyaxes="1 0 0 0 1 2" mode="trackcom"/>
+      <!-- ✅ 已调整相机视角，更远、更清晰 -->
+      <camera name="back" pos="-5 0 1.5" xyaxes="0 -1 0 1 0 2" mode="trackcom"/>
+      <camera name="side" pos="0 -5 1.8" xyaxes="1 0 0 0 1 2" mode="trackcom"/>
       <freejoint name="root"/>
       <geom name="torso" fromto="0 -.07 0 0 .07 0" size=".07"/>
       <geom name="waist_upper" fromto="-.01 -.06 -.12 -.01 .06 -.12" size=".06"/>
       <body name="head" pos="0 0 .19">
         <geom name="head" type="sphere" size=".09"/>
-        <camera name="egocentric" pos=".09 0 0" xyaxes="0 -1 0 .1 0 1" fovy="80"/>
+        <camera name="egocentric" pos=".12 0 0" xyaxes="0 -1 0 .1 0 1" fovy="80"/>
       </body>
       <body name="waist_lower" pos="-.01 0 -.26">
         <geom name="waist_lower" fromto="0 -.06 0 0 .06 0" size=".06"/>
@@ -171,7 +172,7 @@
 
             <!-- 新增：机器人手持刚体部件 -->
             <body name="hold_obj" pos="0.05 0 0">
-              <geom type="box" size="0.05 0.05 0.05" rgba="1 0 0 1"/>
+              <geom type="box" size="0.05 0.05 0.05" rgba="1 0 1 1"/>
             </body>
 
           </body>


### PR DESCRIPTION
修改概述:
调整MuJoCo仿真相机视角，优化back、side、egocentric三个相机的pos位置，提升仿真画面展示效果。

## 修改的详细描述
1. 调整 <camera> 节点的 pos 属性，优化背部视角、侧面视角与第一人称视角的位置。
2. 让机器人模型在仿真中展示更完整、视角更舒适，便于观察动作与传感器效果。
3. 不改动模型结构、传感器、控制逻辑，仅调整视觉参数。

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：3.10
3. 仿真环境：MuJoCo
4. 测试结果：视角切换流畅，机器人展示完整，画面稳定无异常。

## 运行效果
相机视角调整后，可更清晰地观察机器人整体姿态、抬手动作与手持部件，仿真展示效果更直观美观。
<img width="2159" height="1363" alt="image" src="https://github.com/user-attachments/assets/33f8aa6d-f0c5-4fab-9c8d-4131419b8999" />
