### PR TITLE
修改 TransformObservation.observation() 方法中观测维度补零逻辑，将硬编码的 np.zeros(332) 改为动态计算补零长度

### DIFF
--- a/src/humanoid_balance/envs/env_pybullet.py
+++ b/src/humanoid_balance/envs/env_pybullet.py
@@ -6,10 +6,11 @@ class TransformObservation(gym.ObservationWrapper):
     def __init__(self, env):
         super(TransformObservation, self).__init__(env)
         # 显式定义新的观察空间维度 (44 + 332 = 376)
+        self.target_obs_dim = 376  
         self.observation_space = gym.spaces.Box(
             low=-np.inf, 
             high=np.inf, 
-            shape=(376,), 
+            shape=(self.target_obs_dim,), 
             dtype=np.float32
         )
 


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:  
  修改 TransformObservation.observation() 方法中观测维度补零逻辑，将硬编码的 np.zeros(332) 改为动态计算补零长度
## 修改的详细描述
1. 原硬编码补零长度（332）依赖原始观测固定为 44 维，若 HumanoidBulletEnv 配置变化导致原始观测维度改变，会直接引发维度不匹配报错；
2、解决新旧版 Gym 环境 step() 返回值不一致导致的解包错误问题；
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
1. window11
<!-- 请描述所做修改的测试，便于合并 -->

##测试结果
观测维度稳定为376维，多版本 Gym 运行正常
