### PR TITLE
fix: 修复 MyModel.__call__ 中隐藏层的缩进错误

### DIFF
--- a/src/chap04_simple_neural_network/tutorial_minst_fnn-tf2.0-exercise.py
+++ b/src/chap04_simple_neural_network/tutorial_minst_fnn-tf2.0-exercise.py
@@ -61,7 +61,7 @@ class MyModel:
         # 隐藏层+ReLU,隐藏层计算：
         # 通过矩阵乘法（x @ self.W1）加上偏置项 self.b1，得到隐藏层的加权和
         # 使用 ReLU 激活函数增加非线性
-         h = tf.nn.relu(tf.matmul(x, self.W1) + self.b1)
+        h = tf.nn.relu(tf.matmul(x, self.W1) + self.b1)
 
         #  输出层计算：全连接层（无激活函数，直接输出 logits）
         #  - 隐藏层特征（128维） × 权重矩阵 W2（128×10） → 分类评分（10维）


### PR DESCRIPTION
### Summary

- 修复 `MyModel.__call__` 中隐藏层计算的缩进错误：第64行 `h = tf.nn.relu(...)` 有9个前导空格（与 `def` 行同级），应为8个空格（方法体级别），导致 `IndentationError` 无法运行

### 改动文件

`src/chap04_simple_neural_network/tutorial_minst_fnn-tf2.0-exercise.py`

### 问题详情

```python
# 原代码 — 9个前导空格，与 def 行同级
    def __call__(self, x):
        x = tf.reshape(x, [-1, 784])
         h = tf.nn.relu(tf.matmul(x, self.W1) + self.b1)  # IndentationError

# 修复 — 8个前导空格，方法体级别
    def __call__(self, x):
        x = tf.reshape(x, [-1, 784])
        h = tf.nn.relu(tf.matmul(x, self.W1) + self.b1)
```

### 测试

该修复基于代码审查，不涉及运行效果。缩进错误是确定性 bug。