### PR TITLE
fix: 移除 softmax_ce 中重复的 tf.cast 调用

### DIFF
--- a/src/chap04_simple_neural_network/tf2.0-exercise.py
+++ b/src/chap04_simple_neural_network/tf2.0-exercise.py
@@ -82,8 +82,6 @@ def softmax_ce(logits, label):
     # 参数label: one-hot格式的标签
     # 定义一个极小值epsilon（1e-8），用于数值稳定性，防止log(0)的情况
     epsilon = 1e-8
-    logits = tf.cast(logits, tf.float32)
-    label = tf.cast(label, tf.float32)
     # 数值稳定处理：减去最大值
     logits_max = tf.stop_gradient(tf.reduce_max(logits, axis = -1, keepdims = True))
     stable_logits = logits - logits_max


### PR DESCRIPTION
### Summary

- 移除 `softmax_ce` 函数中重复的 `tf.cast` 调用：`logits` 和 `label` 在函数开头（第79-80行）已被转换为 `tf.float32`，第85-86行的第二次转换是冗余的死代码

### 改动文件

`src/chap04_simple_neural_network/tf2.0-exercise.py`

### 问题详情

```python
def softmax_ce(logits, label):
    logits = tf.cast(logits, tf.float32)  # 第79行 — 第一次转换
    label = tf.cast(label, tf.float32)    # 第80行 — 第一次转换
    epsilon = 1e-8
    logits = tf.cast(logits, tf.float32)  # 第85行 — 重复！
    label = tf.cast(label, tf.float32)    # 第86行 — 重复！
```

### 测试

该修复基于代码审查，不涉及运行效果。删除重复代码是确定性修复。
