### PR TITLE
fix: 移除未使用的 rc 和 cm 导入

### DIFF
--- a/src/chap03_softmax_regression/softmax_regression-exercise.py
+++ b/src/chap03_softmax_regression/softmax_regression-exercise.py
@@ -13,8 +13,7 @@
 # 导入运行所需模块
 import tensorflow as tf # TensorFlow深度学习框架
 import matplotlib.pyplot as plt # 数据可视化库
-from matplotlib import animation, rc # 动画功能
-import matplotlib.cm as cm # 颜色映射
+from matplotlib import animation # 动画功能
 import numpy as np # 数值计算库
 import os # 读取环境变量参数
 import json # 保存实验指标


### PR DESCRIPTION
### Summary

- 移除未使用的 `rc` 导入（from matplotlib）
- 移除未使用的 `cm` 导入（matplotlib.cm）

### 改动文件

`src/chap03_softmax_regression/softmax_regression-exercise.py`

### 问题详情

```python
# 原代码
from matplotlib import animation, rc  # rc 从未使用
import matplotlib.cm as cm  # cm 从未使用

# 修复
from matplotlib import animation
```

`animation` 保留是因为在文件中被使用（`animation.FuncAnimation`）。

### 测试

该修复基于代码审查，不涉及运行效果。移除未使用导入是确定性修复。