### PR TITLE
fix: 修复docs/index.md中的路径分隔符

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ title: 主页
 
 ## 入门 <span id="primary"></span>
 
-[__11__](carla_traffic_sign_recognition\carla_traffic_sign_recognition.md) — 入门热身示例  
+[__11__](carla_traffic_sign_recognition/carla_traffic_sign_recognition.md) — 入门热身示例  
 [__热身__](warmup.md) — 入门热身示例
 
 [__线性回归__](linear_regression.md)


### PR DESCRIPTION
**描述**:
## Summary
- 修复docs/index.md文件中第16行的路径分隔符问题
- 将Windows反斜杠路径 `\` 改为正斜杠路径 `/`
- 确保文档链接在非Windows环境下（如Linux、macOS）也能正常工作

## Test plan
- 检查docs/index.md中的链接是否在Linux/macOS环境下可正常访问
- 验证修改后的路径格式是否符合跨平台标准