### PR TITLE
fix: 修复mkdocs搜索语言配置

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ extra_javascript:
 plugins:
 #  - mkdocs-video
   - search:
-      lang: ja
+      lang: zh
       separator: '[\s\-\.]+'
       min_search_length: 3
 


### PR DESCRIPTION
**描述**:
## Summary
- 修复mkdocs.yml中的搜索语言配置
- 将搜索语言从日语(ja)改为中文(zh)
- 与项目主要内容语言保持一致，提升搜索体验

## Test plan
- 验证mkdocs构建后的搜索功能是否正常工作
- 检查搜索结果是否正确匹配中文内容
