### PR TITLE
fix: 清理.gitignore中的重复条目

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,29 +141,7 @@ desktop.ini
 site/
 .claude/
 # =========================================
-# Added by contributor: development tools
+# 环境变量文件
 # =========================================
-
-# Pytest
-.pytest_cache/
-
-# Coverage
-.coverage
-htmlcov/
-
-# VSCode
-.vscode/
-
-# JetBrains IDE
-.idea/
-
-# Temporary files
-*.tmp
-*.temp
-
-# Environment files
 .env.local
 .env.*.local
-
-# Jupyter
-.ipynb_checkpoints/


### PR DESCRIPTION
**描述**:
## Summary
- 清理.gitignore文件中的重复忽略规则
- 移除以下重复条目：.pytest_cache/、.coverage、htmlcov/、.vscode/、.idea/、*.tmp、*.temp、.ipynb_checkpoints/
- 保留首次出现的条目，删除后续重复声明，使配置更简洁

## Test plan
- 验证gitignore规则仍然正确生效
- 确认没有遗漏需要忽略的文件类型