### PR TITLE
增加分屏结果保存、运行进度显示、FPS显示

### DIFF
--- a/src/openpilot_model/main.py
+++ b/src/openpilot_model/main.py
@@ -1,127 +1,308 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+"""Lane detection demo with stable Hough lane fitting."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
 import cv2
 import numpy as np
-import sys
-import time
 
-def lane_detection(frame):
-    """基础车道线检测（适配道路视频）"""
-    # 预处理：灰度→模糊→边缘检测
-    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-    blur = cv2.GaussianBlur(gray, (5,5), 0)
-    edges = cv2.Canny(blur, 50, 150)
-    
-    # 掩码聚焦车道区域（只检测画面下半部分）
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+WHITE_LOWER = np.array([0, 120, 0], dtype=np.uint8)
+WHITE_UPPER = np.array([180, 255, 170], dtype=np.uint8)
+YELLOW_LOWER = np.array([15, 70, 70], dtype=np.uint8)
+YELLOW_UPPER = np.array([40, 255, 255], dtype=np.uint8)
+
+
+@dataclass
+class LaneSmoother:
+    max_history: int = 8
+    left_history: list[np.ndarray] = field(default_factory=list)
+    right_history: list[np.ndarray] = field(default_factory=list)
+
+    def update(self, left_fit: np.ndarray | None, right_fit: np.ndarray | None) -> tuple[np.ndarray | None, np.ndarray | None]:
+        if left_fit is not None:
+            self.left_history.append(left_fit)
+            self.left_history = self.left_history[-self.max_history :]
+        if right_fit is not None:
+            self.right_history.append(right_fit)
+            self.right_history = self.right_history[-self.max_history :]
+
+        left = np.mean(self.left_history, axis=0) if self.left_history else None
+        right = np.mean(self.right_history, axis=0) if self.right_history else None
+        return left, right
+
+
+def build_trapezoid_roi(width: int, height: int) -> np.ndarray:
+    """Return a road-focused trapezoid region of interest."""
+    top_y = int(height * 0.58)
+    bottom_y = height
+    top_half_width = int(width * 0.11)
+    bottom_margin = int(width * 0.05)
+    center_x = width // 2
+
+    return np.array(
+        [
+            [
+                (bottom_margin, bottom_y),
+                (center_x - top_half_width, top_y),
+                (center_x + top_half_width, top_y),
+                (width - bottom_margin, bottom_y),
+            ]
+        ],
+        dtype=np.int32,
+    )
+
+
+def color_filter(frame: np.ndarray) -> np.ndarray:
+    """Prefer white and yellow lane markings in HLS color space."""
+    hls = cv2.cvtColor(frame, cv2.COLOR_BGR2HLS)
+    white_mask = cv2.inRange(hls, WHITE_LOWER, WHITE_UPPER)
+    yellow_mask = cv2.inRange(hls, YELLOW_LOWER, YELLOW_UPPER)
+    mask = cv2.bitwise_or(white_mask, yellow_mask)
+
+    kernel = np.ones((3, 3), dtype=np.uint8)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=1)
+    return cv2.dilate(mask, kernel, iterations=1)
+
+
+def weighted_lane_fit(lines: Iterable[np.ndarray] | None, width: int, height: int) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Fit scattered Hough segments into one left and one right lane line."""
+    if lines is None:
+        return None, None
+
+    left_lines: list[tuple[float, float]] = []
+    right_lines: list[tuple[float, float]] = []
+    left_weights: list[float] = []
+    right_weights: list[float] = []
+    mid_x = width / 2
+    y_top = int(height * 0.62)
+    y_bottom = height
+
+    for line in lines:
+        x1, y1, x2, y2 = line[0]
+        if x1 == x2:
+            continue
+
+        slope = (y2 - y1) / (x2 - x1)
+        if abs(slope) < 0.35 or abs(slope) > 3.5:
+            continue
+
+        intercept = y1 - slope * x1
+        length = float(np.hypot(x2 - x1, y2 - y1))
+        x_at_top = (y_top - intercept) / slope
+        x_at_bottom = (y_bottom - intercept) / slope
+
+        if slope < 0 and x_at_top < mid_x and x_at_bottom < width * 0.72:
+            left_lines.append((slope, intercept))
+            left_weights.append(length)
+        elif slope > 0 and x_at_top > mid_x and x_at_bottom > width * 0.55:
+            right_lines.append((slope, intercept))
+            right_weights.append(length)
+
+    left_fit = np.average(left_lines, axis=0, weights=left_weights) if left_lines else None
+    right_fit = np.average(right_lines, axis=0, weights=right_weights) if right_lines else None
+    return left_fit, right_fit
+
+
+def line_points(fit: np.ndarray | None, y_top: int, y_bottom: int, width: int) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    if fit is None:
+        return None
+
+    slope, intercept = fit
+    if abs(slope) < 1e-3:
+        return None
+
+    x_top = int((y_top - intercept) / slope)
+    x_bottom = int((y_bottom - intercept) / slope)
+    x_top = max(-width, min(width * 2, x_top))
+    x_bottom = max(-width, min(width * 2, x_bottom))
+    return (x_top, y_top), (x_bottom, y_bottom)
+
+
+def lane_detection(frame: np.ndarray, smoother: LaneSmoother) -> np.ndarray:
     h, w = frame.shape[:2]
-    roi_vertices = np.array([[(0, h), (w//2, h//2), (w, h)]], dtype=np.int32)
-    mask = np.zeros_like(edges)
-    cv2.fillPoly(mask, roi_vertices, 255)
-    masked_edges = cv2.bitwise_and(edges, mask)
-    
-    # 霍夫变换检测车道线
+    color_mask = color_filter(frame)
+    blur = cv2.GaussianBlur(color_mask, (5, 5), 0)
+    edges = cv2.Canny(blur, 40, 120)
+
+    roi_vertices = build_trapezoid_roi(w, h)
+    roi_mask = np.zeros_like(edges)
+    cv2.fillPoly(roi_mask, roi_vertices, 255)
+    masked_edges = cv2.bitwise_and(edges, roi_mask)
+
     lines = cv2.HoughLinesP(
         masked_edges,
         rho=1,
-        theta=np.pi/180,
-        threshold=20,
-        minLineLength=40,
-        maxLineGap=20
+        theta=np.pi / 180,
+        threshold=18,
+        minLineLength=25,
+        maxLineGap=120,
     )
-    
-    # 绘制车道线（红=左，蓝=右）
-    detected = frame.copy()
-    if lines is not None:
-        mid_x = w / 2
-        for line in lines:
-            x1, y1, x2, y2 = line[0]
-            slope = (y2 - y1) / (x2 - x1) if (x2 - x1) != 0 else 0
-            # 左车道线（负斜率）、右车道线（正斜率）
-            if slope < -0.3 and x1 < mid_x:
-                cv2.line(detected, (x1, y1), (x2, y2), (0, 0, 255), 4)
-            elif slope > 0.3 and x1 > mid_x:
-                cv2.line(detected, (x1, y1), (x2, y2), (255, 0, 0), 4)
-    return detected
 
-def main(video_path):
-    # 打开视频（强制指定解码器，兼容更多格式）
-    cap = cv2.VideoCapture(video_path, cv2.CAP_FFMPEG)
+    left_fit, right_fit = weighted_lane_fit(lines, w, h)
+    left_fit, right_fit = smoother.update(left_fit, right_fit)
+
+    detected = frame.copy()
+    overlay = np.zeros_like(frame)
+    y_top = int(h * 0.62)
+    y_bottom = h
+
+    left_points = line_points(left_fit, y_top, y_bottom, w)
+    right_points = line_points(right_fit, y_top, y_bottom, w)
+
+    cv2.polylines(detected, roi_vertices, True, (0, 255, 255), 2)
+
+    if left_points is not None:
+        cv2.line(overlay, left_points[0], left_points[1], (0, 0, 255), 10)
+    if right_points is not None:
+        cv2.line(overlay, right_points[0], right_points[1], (255, 0, 0), 10)
+    if left_points is not None and right_points is not None:
+        lane_area = np.array([left_points[1], left_points[0], right_points[0], right_points[1]], dtype=np.int32)
+        cv2.fillPoly(overlay, [lane_area], (0, 180, 0))
+
+    return cv2.addWeighted(detected, 1.0, overlay, 0.35, 0)
+
+
+def draw_hud(frame: np.ndarray, frame_idx: int, total_frames: int, fps: float, output_path: Path) -> None:
+    h, w = frame.shape[:2]
+    progress = (frame_idx / total_frames) if total_frames > 0 else 0.0
+    progress_text = f"{progress * 100:5.1f}%" if total_frames > 0 else "  N/A"
+
+    cv2.rectangle(frame, (0, 0), (w, 74), (0, 0, 0), -1)
+    cv2.putText(frame, f"FPS: {fps:5.1f}", (18, 28), cv2.FONT_HERSHEY_SIMPLEX, 0.72, (0, 255, 255), 2)
+    cv2.putText(frame, f"Frame: {frame_idx}/{total_frames if total_frames > 0 else '?'}", (180, 28), cv2.FONT_HERSHEY_SIMPLEX, 0.72, (255, 255, 255), 2)
+    cv2.putText(frame, f"Progress: {progress_text}", (18, 60), cv2.FONT_HERSHEY_SIMPLEX, 0.64, (255, 255, 255), 2)
+    cv2.putText(frame, f"Output: {output_path.name}", (330, 60), cv2.FONT_HERSHEY_SIMPLEX, 0.56, (180, 220, 255), 1)
+
+    bar_x, bar_y, bar_w, bar_h = w - 260, 24, 220, 14
+    cv2.rectangle(frame, (bar_x, bar_y), (bar_x + bar_w, bar_y + bar_h), (80, 80, 80), 1)
+    cv2.rectangle(frame, (bar_x, bar_y), (bar_x + int(bar_w * progress), bar_y + bar_h), (0, 200, 0), -1)
+
+
+def process_video(video_path: Path, output_dir: Path, display: bool, save_every: int, max_frames: int) -> tuple[Path, Path | None, int]:
+    cap = cv2.VideoCapture(str(video_path), cv2.CAP_FFMPEG)
     if not cap.isOpened():
-        print(f"错误：无法打开视频 {video_path}")
-        return
-    
-    # 获取视频基础信息
-    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = int(cap.get(cv2.CAP_PROP_FPS)) or 30
+        raise RuntimeError(f"Cannot open video: {video_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    source_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    
-    # 强制创建分屏窗口（固定尺寸，避免压缩）
-    cv2.namedWindow("Lane Detection - Split Screen", cv2.WINDOW_NORMAL)
-    cv2.resizeWindow("Lane Detection - Split Screen", w*2, h)
-    
-    # 视频写入器（保存分屏结果）
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-    out = cv2.VideoWriter("/home/dacun/nn/road_detection.mp4", fourcc, fps, (w*2, h))
-    
-    print("=== 分屏车道线检测（强制窗口显示）===")
-    print(f"视频尺寸：{w}x{h} | 总帧数：{total_frames}")
-    print("操作说明：")
-    print("  Q键 → 退出")
-    print("  P键 → 暂停/继续")
-    print("  空格 → 单步播放")
-    
-    paused = False
-    step_mode = False
+    progress_total = max_frames if max_frames > 0 else total_frames
+    output_path = output_dir / f"{video_path.stem}_lane_detection.mp4"
+    screenshot_dir = output_dir / "screenshots"
+    screenshot_dir.mkdir(exist_ok=True)
+
+    writer = cv2.VideoWriter(
+        str(output_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        source_fps,
+        (width * 2, height),
+    )
+
+    smoother = LaneSmoother()
     frame_idx = 0
-    
-    # 核心播放循环（强制逐帧显示）
+    last_time = time.perf_counter()
+    first_screenshot: Path | None = None
+
+    print("=== Lane Detection Split Screen ===")
+    print(f"Input: {video_path}")
+    print(f"Size: {width}x{height} | FPS: {source_fps:.2f} | Total frames: {progress_total if progress_total > 0 else 'unknown'}")
+    print(f"Output video: {output_path}")
+    print("Keys: q=quit, p=pause, s=save screenshot")
+
+    paused = False
+    current_frame: np.ndarray | None = None
+
     while True:
-        # 单步/暂停逻辑
-        if not paused or step_mode:
+        if not paused:
             ret, frame = cap.read()
             if not ret:
-                print(f"\n播放完成！已处理 {frame_idx} 帧")
                 break
-            
-            # 检测车道线 + 生成分屏
-            detected_frame = lane_detection(frame)
-            split_frame = np.hstack((frame, detected_frame))  # 左右拼接
-            
-            # 绘制分屏标题
-            cv2.putText(split_frame, "原始画面", (20, 30), 
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255,255,255), 2)
-            cv2.putText(split_frame, "车道线检测", (w+20, 30), 
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255,255,255), 2)
-            
-            # 保存分屏帧
-            out.write(split_frame)
+
             frame_idx += 1
-            step_mode = False
-        
-        # 强制显示窗口（核心：即使无新帧，也刷新窗口）
-        cv2.imshow("Lane Detection - Split Screen", split_frame)
-        
-        # 按键控制（降低等待时间，确保窗口响应）
-        key = cv2.waitKey(1) & 0xFF
-        if key == ord('q'):
-            print(f"\n手动退出！已处理 {frame_idx} 帧")
-            break
-        elif key == ord('p'):
-            paused = not paused
-            print(f"{'暂停' if paused else '继续'}播放")
-        elif key == ord(' '):
-            step_mode = True
-            paused = True  # 单步时自动暂停
-    
-    # 释放资源
+            detected_frame = lane_detection(frame, smoother)
+            split_frame = np.hstack((frame, detected_frame))
+
+            now = time.perf_counter()
+            fps = 1.0 / max(now - last_time, 1e-6)
+            last_time = now
+
+            cv2.putText(split_frame, "Original", (20, 34), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 255, 255), 2)
+            cv2.putText(split_frame, "Lane Detection", (width + 20, 34), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (255, 255, 255), 2)
+            draw_hud(split_frame, frame_idx, progress_total, fps, output_path)
+
+            writer.write(split_frame)
+            current_frame = split_frame
+
+            if save_every > 0 and frame_idx % save_every == 0:
+                screenshot_path = screenshot_dir / f"frame_{frame_idx:06d}.jpg"
+                cv2.imwrite(str(screenshot_path), split_frame)
+                first_screenshot = first_screenshot or screenshot_path
+
+            if progress_total > 0 and frame_idx % max(1, int(source_fps)) == 0:
+                print(f"\rProcessed {frame_idx}/{progress_total} frames ({frame_idx / progress_total * 100:.1f}%)", end="")
+
+            if max_frames > 0 and frame_idx >= max_frames:
+                break
+
+        if display and current_frame is not None:
+            cv2.imshow("Lane Detection - Split Screen", current_frame)
+            key = cv2.waitKey(1) & 0xFF
+            if key == ord("q"):
+                break
+            if key == ord("p"):
+                paused = not paused
+            if key == ord("s"):
+                screenshot_path = screenshot_dir / f"frame_{frame_idx:06d}_manual.jpg"
+                cv2.imwrite(str(screenshot_path), current_frame)
+                first_screenshot = first_screenshot or screenshot_path
+                print(f"\nScreenshot saved: {screenshot_path}")
+        elif not display and current_frame is not None:
+            # Headless mode still writes one representative screenshot for reports.
+            if first_screenshot is None and frame_idx == 1:
+                screenshot_path = screenshot_dir / "frame_000001_auto.jpg"
+                cv2.imwrite(str(screenshot_path), current_frame)
+                first_screenshot = screenshot_path
+
+    print()
     cap.release()
-    out.release()
-    cv2.destroyAllWindows()
-    print(f"分屏检测视频已保存：/home/dacun/nn/road_detection.mp4")
+    writer.release()
+    if display:
+        cv2.destroyAllWindows()
+
+    print(f"Done. Processed frames: {frame_idx}")
+    print(f"Saved video: {output_path}")
+    if first_screenshot is not None:
+        print(f"Saved screenshot: {first_screenshot}")
+
+    return output_path, first_screenshot, frame_idx
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Detect lane lines in a driving video.")
+    parser.add_argument("video", type=Path, help="Input video path")
+    parser.add_argument("--output-dir", type=Path, default=OUTPUT_DIR, help="Directory for video and screenshots")
+    parser.add_argument("--no-display", action="store_true", help="Run without opening an OpenCV window")
+    parser.add_argument("--save-every", type=int, default=0, help="Save a screenshot every N frames")
+    parser.add_argument("--max-frames", type=int, default=0, help="Stop after N frames; 0 means process the whole video")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    process_video(args.video, args.output_dir, display=not args.no_display, save_every=args.save_every, max_frames=args.max_frames)
+
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print(f"用法：{sys.argv[0]} <视频路径>")
-        sys.exit(1)
-    main(sys.argv[1])
+    main()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     将车道检测 ROI 从三角形改为梯形区域，提高不同道路视角下的适配性。增加 HLS 颜色过滤，优先检测白色和黄色车道线。将 Hough 检测到的零散线段拟合为左右两条稳定车道线。增加 output 输出目录，避免输出路径写死。增加 FPS、帧号、进度显示和截图保存功能。
<!-- Fixes: # -->
<!-- Fixes: # -->

## 修改的详细描述
1. 重构 `main.py`，新增梯形 ROI、HLS 白/黄车道线掩码、Hough 线段左右分组、加权拟合和历史平滑逻辑。
2. 新增命令行参数：`--output-dir`、`--no-display`、`--save-every`、`--max-frames`，便于本地运行、无窗口测试和生成运行材料。
3. 输出统一保存到 `src/openpilot_model/output/`，包括分屏检测视频和截图。
4. 在输出画面顶部叠加 FPS、帧号、进度百分比、进度条和输出文件名。

## 经过了什么样的测试?
1. 操作系统：Windows
2. Python版本：Python 3.10.6
3. 语法检查：`D:\Python\python.exe -m py_compile main.py`
4. 样例运行：使用 `sample.hevc` 无窗口处理前 120 帧，成功生成视频和截图。

## 运行效果
<img width="2328" height="874" alt="frame_000060" src="https://github.com/user-attachments/assets/665e956f-4b46-4186-b468-f217c94a4aad" />
<img width="2328" height="874" alt="frame_000120" src="https://github.com/user-attachments/assets/af535d46-2100-48b8-addc-1b5c6664e13e" />

