### PR TITLE
机械臂可视化窗口关闭时添加资源清理，防止matplotlib残留进程

### DIFF
--- a/src/mechanical_arm/main.py
+++ b/src/mechanical_arm/main.py
@@ -1,3 +1,4 @@
+import atexit
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button
@@ -22,7 +23,12 @@ class RoboticArmWithGripper:
 
         # 初始化图形
         self.fig = plt.figure(figsize=(14, 8))
+        self.fig.canvas.mpl_connect('close_event', self._on_close)
         self.setup_plot()
+
+    def _on_close(self, event):
+        """窗口关闭时释放资源"""
+        plt.close(self.fig)
 
     def update_dh_params(self):
         """更新DH参数"""
@@ -430,9 +436,14 @@ def main():
     # 创建机械臂实例
     arm = RoboticArmWithGripper()
 
-    # 显示交互式界面
-    plt.show()
+    # 注册清理函数
+    atexit.register(plt.close, 'all')
+
+    try:
+        plt.show()
+    finally:
+        plt.close('all')
 
 
 if __name__ == "__main__":
-    main()#结束过程
+    main()


### PR DESCRIPTION
修改概述: 为机械臂可视化模块添加窗口关闭时的资源清理机制

## 修改的详细描述
1. 新增 `_on_close()` 方法：监听matplotlib窗口关闭事件，主动释放图形资源
2. 使用 `atexit.register(plt.close, 'all')` 注册退出清理函数，确保程序退出时关闭所有图形窗口
3. 使用 `try-finally` 包裹 `plt.show()`，异常退出时也能保证资源释放
4. 修复 `main()#结束过程` 代码与注释缺少空格的格式问题

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python版本：Python 3.8+ / Anaconda
3. 依赖库：numpy 1.21.0, matplotlib 3.7.5
4. 测试场景：
   - 正常关闭窗口 → 程序正常退出，无警告
   - 点击X按钮关闭 → CMD无报错，进程正常结束
   - 程序运行中操作滑块和按钮 → 功能正常

## 运行效果
改进前：
- 关闭窗口后可能出现matplotlib残留进程
- 异常退出时图形资源可能未释放
- 代码末尾格式不规范

改进后：
- 窗口关闭时主动调用 plt.close() 释放资源
- 程序退出时通过 atexit 保证清理
- 异常路径也能通过 finally 完成清理
- 代码格式规范
<img width="675" height="687" alt="c9b356f5-a219-45ad-af78-991a18b3e8b3" src="https://github.com/user-attachments/assets/49958df9-9543-41ee-b695-fbb9e3620c09" />
