### PR TITLE
机械臂动画函数添加中断处理，窗口关闭时安全停止动画

### DIFF
--- a/src/mechanical_arm/main.py
+++ b/src/mechanical_arm/main.py
@@ -17,6 +17,9 @@ class RoboticArmWithGripper:
         self.gripper_opening = 0.2  # 夹爪开口大小
         self.gripper_angle = 0.0  # 夹爪旋转角度
 
+        # 动画状态
+        self._animating = False
+
         # DH参数
         self.update_dh_params()
 
@@ -246,30 +249,49 @@ class RoboticArmWithGripper:
         self.slider_gripper_open.set_val(0.2)
         self.slider_gripper_rotate.set_val(0.0)
 
+    def _safe_pause(self, seconds):
+        """带中断检查的暂停，窗口关闭时提前返回"""
+        if not self._animating:
+            return False
+        try:
+            plt.pause(seconds)
+            return True
+        except Exception:
+            self._animating = False
+            return False
+
     def grasp_demo(self, event):
         """抓取演示动画"""
-        # 保存原始开口大小
+        self._animating = True
         original_opening = self.gripper_opening
 
         # 闭合夹爪
         for i in range(20):
+            if not self._animating:
+                break
             self.gripper_opening = original_opening * (1 - i / 20)
             self.slider_gripper_open.set_val(self.gripper_opening)
             self.update_plot()
-            plt.pause(0.05)
+            if not self._safe_pause(0.05):
+                break
 
-        plt.pause(0.5)
+        self._safe_pause(0.5)
 
         # 打开夹爪
         for i in range(20):
+            if not self._animating:
+                break
             self.gripper_opening = original_opening * (i / 20)
             self.slider_gripper_open.set_val(self.gripper_opening)
             self.update_plot()
-            plt.pause(0.05)
+            if not self._safe_pause(0.05):
+                break
+
+        self._animating = False
 
     def animate_movement(self, event):
         """动画演示"""
-        # 保存原始角度
+        self._animating = True
         original_angles = self.joint_angles.copy()
 
         # 定义动画路径
@@ -280,28 +302,39 @@ class RoboticArmWithGripper:
             original_angles
         ]
 
-        for target_angles in path:
-            # 平滑移动到目标角度
+        try:
+            for target_angles in path:
+                if not self._animating:
+                    break
+                for i in range(20):
+                    if not self._animating:
+                        break
+                    for j in range(4):
+                        current = self.joint_angles[j]
+                        target = target_angles[j]
+                        self.joint_angles[j] = current + (target - current) * (i + 1) / 20
+                    self.update_dh_params()
+                    self.update_plot()
+                    if not self._safe_pause(0.03):
+                        break
+
+                if not self._safe_pause(0.5):
+                    break
+
+            # 恢复原始角度
             for i in range(20):
+                if not self._animating:
+                    break
                 for j in range(4):
                     current = self.joint_angles[j]
-                    target = target_angles[j]
+                    target = original_angles[j]
                     self.joint_angles[j] = current + (target - current) * (i + 1) / 20
                 self.update_dh_params()
                 self.update_plot()
-                plt.pause(0.03)
-
-            plt.pause(0.5)
-
-        # 恢复原始角度
-        for i in range(20):
-            for j in range(4):
-                current = self.joint_angles[j]
-                target = original_angles[j]
-                self.joint_angles[j] = current + (target - current) * (i + 1) / 20
-            self.update_dh_params()
-            self.update_plot()
-            plt.pause(0.03)
+                if not self._safe_pause(0.03):
+                    break
+        finally:
+            self._animating = False
 
     def update_plot(self):
         """更新所有图形"""


### PR DESCRIPTION
修改概述: 为机械臂动画函数添加中断处理机制，窗口关闭时安全停止动画

## 修改的详细描述
1. 新增 `_animating` 状态标志：跟踪动画是否正在执行
2. 新增 `_safe_pause()` 方法：带中断检查的暂停函数，窗口关闭时捕获异常并提前返回
3. 改进 `grasp_demo()`：每个动画步骤检查中断标志，异常时安全退出
4. 改进 `animate_movement()`：使用 `try-finally` 确保动画状态正确重置
5. 所有 `plt.pause()` 调用替换为 `_safe_pause()`，防止窗口关闭时抛出未捕获异常

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python版本：Python 3.8+ / Anaconda
3. 依赖库：numpy 1.21.0, matplotlib 3.7.5
4. 测试场景：
   - 点击 Animate 按钮正常播放动画 → 运行正常
   - 点击 Grasp Demo 按钮正常播放 → 运行正常
   - 动画播放中关闭窗口 → 程序正常退出，无报错

## 运行效果
改进前：
- 动画播放中关闭窗口会抛出异常
- `plt.pause()` 在窗口关闭后仍然阻塞
- 动画状态无法恢复

改进后：
- 动画播放中关闭窗口，`_safe_pause()` 捕获异常并返回 False
- 动画循环检测到中断标志后立即退出
- `try-finally` 确保无论正常还是异常退出，`_animating` 都被重置为 False
<img width="786" height="413" alt="image" src="https://github.com/user-attachments/assets/f17cafd0-bff9-4747-be08-e1c5037285bb" />
