### PR TITLE
修复按钮鼠标抢占冲突，patch canvas.grab_mouse捕获RuntimeError

### DIFF
--- a/src/mechanical_arm/main.py
+++ b/src/mechanical_arm/main.py
@@ -1,4 +1,3 @@
-import threading
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button
@@ -18,15 +17,26 @@ class RoboticArmWithGripper:
         self.gripper_opening = 0.2  # 夹爪开口大小
         self.gripper_angle = 0.0  # 夹爪旋转角度
 
-        # 按钮防重入锁
-        self._button_lock = threading.Lock()
-
         # DH参数
         self.update_dh_params()
 
         # 初始化图形
         self.fig = plt.figure(figsize=(14, 8))
+        self._patch_grab_mouse()
         self.setup_plot()
+
+    def _patch_grab_mouse(self):
+        """修补matplotlib的grab_mouse，避免多控件鼠标抢占冲突"""
+        canvas = self.fig.canvas
+        original_grab = canvas.grab_mouse
+
+        def safe_grab(ax):
+            try:
+                original_grab(ax)
+            except RuntimeError:
+                pass
+
+        canvas.grab_mouse = safe_grab
 
     def update_dh_params(self):
         """更新DH参数"""
@@ -242,29 +252,16 @@ class RoboticArmWithGripper:
 
     def reset_all(self, event):
         """重置所有参数"""
-        if not self._button_lock.acquire(blocking=False):
-            return
-        try:
-            # 重置关节角度
-            for i, slider in enumerate(self.sliders):
-                slider.set_val(0.0)
+        # 重置关节角度
+        for i, slider in enumerate(self.sliders):
+            slider.set_val(0.0)
 
-            # 重置夹爪
-            self.slider_gripper_open.set_val(0.2)
-            self.slider_gripper_rotate.set_val(0.0)
-        finally:
-            self._button_lock.release()
+        # 重置夹爪
+        self.slider_gripper_open.set_val(0.2)
+        self.slider_gripper_rotate.set_val(0.0)
 
     def grasp_demo(self, event):
         """抓取演示动画"""
-        if not self._button_lock.acquire(blocking=False):
-            return
-        try:
-            self._grasp_demo_impl(event)
-        finally:
-            self._button_lock.release()
-
-    def _grasp_demo_impl(self, event):
         original_opening = self.gripper_opening
 
         # 闭合夹爪
@@ -285,14 +282,7 @@ class RoboticArmWithGripper:
 
     def animate_movement(self, event):
         """动画演示"""
-        if not self._button_lock.acquire(blocking=False):
-            return
-        try:
-            self._animate_movement_impl(event)
-        finally:
-            self._button_lock.release()
-
-    def _animate_movement_impl(self, event):
+        # 保存原始角度
         original_angles = self.joint_angles.copy()
 
         # 定义动画路径

--- a/src/mechanical_arm/main.py
+++ b/src/mechanical_arm/main.py
@@ -1,3 +1,4 @@
+import threading
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button
@@ -16,6 +17,9 @@ class RoboticArmWithGripper:
         self.gripper_width = 0.15  # 夹爪宽度
         self.gripper_opening = 0.2  # 夹爪开口大小
         self.gripper_angle = 0.0  # 夹爪旋转角度
+
+        # 按钮防重入锁
+        self._button_lock = threading.Lock()
 
         # DH参数
         self.update_dh_params()
@@ -238,17 +242,29 @@ class RoboticArmWithGripper:
 
     def reset_all(self, event):
         """重置所有参数"""
-        # 重置关节角度
-        for i, slider in enumerate(self.sliders):
-            slider.set_val(0.0)
+        if not self._button_lock.acquire(blocking=False):
+            return
+        try:
+            # 重置关节角度
+            for i, slider in enumerate(self.sliders):
+                slider.set_val(0.0)
 
-        # 重置夹爪
-        self.slider_gripper_open.set_val(0.2)
-        self.slider_gripper_rotate.set_val(0.0)
+            # 重置夹爪
+            self.slider_gripper_open.set_val(0.2)
+            self.slider_gripper_rotate.set_val(0.0)
+        finally:
+            self._button_lock.release()
 
     def grasp_demo(self, event):
         """抓取演示动画"""
-        # 保存原始开口大小
+        if not self._button_lock.acquire(blocking=False):
+            return
+        try:
+            self._grasp_demo_impl(event)
+        finally:
+            self._button_lock.release()
+
+    def _grasp_demo_impl(self, event):
         original_opening = self.gripper_opening
 
         # 闭合夹爪
@@ -269,7 +285,14 @@ class RoboticArmWithGripper:
 
     def animate_movement(self, event):
         """动画演示"""
-        # 保存原始角度
+        if not self._button_lock.acquire(blocking=False):
+            return
+        try:
+            self._animate_movement_impl(event)
+        finally:
+            self._button_lock.release()
+
+    def _animate_movement_impl(self, event):
         original_angles = self.joint_angles.copy()
 
         # 定义动画路径


### PR DESCRIPTION
修改概述: 修复机械臂可视化模块中多控件鼠标抢占导致的RuntimeError

## 修改的详细描述
1. 新增 `_patch_grab_mouse()` 方法：对matplotlib canvas的 `grab_mouse` 进行安全包装
2. 保留原始 `grab_mouse` 引用，包装后捕获 `RuntimeError` 并忽略
3. 在图形初始化时调用patch，确保所有控件的鼠标抢占冲突被静默处理

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python版本：Python 3.8+ / Anaconda
3. 依赖库：numpy 1.21.0, matplotlib 3.7.5
4. 测试场景：
   - 点击 Animate 按钮后关闭窗口 → 无 RuntimeError 报错
   - 点击 Grasp Demo 按钮后关闭窗口 → 无报错
   - 快速连续点击不同按钮 → 无冲突
   - 滑块操作后点击按钮 → 正常运行

## 运行效果
改进前：
- 点击按钮后关闭窗口报错：RuntimeError: Another Axes already grabs mouse input
- 滑块和按钮交互时触发鼠标抢占冲突

改进后：
- 多控件交互不再抛出 RuntimeError
- 按钮和滑块操作互不干扰
- 程序退出干净，无残留异常                修复前：
<img width="1253" height="590" alt="d3613a9a-8c50-4052-bbbb-3b0cb06413d3" src="https://github.com/user-attachments/assets/dcf7a620-e484-4573-a22a-e320be6f9e6f" />
xiufu修复后
<img width="1309" height="461" alt="e19e1e11-2eae-4031-8720-c9bdc9e16c33" src="https://github.com/user-attachments/assets/701cf76d-0af5-4b94-b8f3-4395558d36db" />
