### PR TITLE
修复visualize参数逻辑bug，支持命令行控制训练轮数和可视化

### DIFF
--- a/src/robot_navigation_system/main.py
+++ b/src/robot_navigation_system/main.py
@@ -6,18 +6,19 @@ def main():
     parser.add_argument('--mode', type=str, default='train', choices=['train', 'test'],
                         help='运行模式: train（训练）或 test（测试）')
     parser.add_argument('--episodes', type=int, default=500, help='训练轮数')
-    parser.add_argument('--visualize', action='store_true', default=True, help='是否可视化')
-    
+    parser.add_argument('--visualize', action='store_true', default=False, help='是否可视化')
+    parser.add_argument('--no-visualize', dest='visualize', action='store_false', help='关闭可视化')
+
     args = parser.parse_args()
-    
+
     os.makedirs('./results', exist_ok=True)
-    
+
     if args.mode == 'train':
         from train import train
-        train()
+        train(episodes=args.episodes, visualize=args.visualize)
     elif args.mode == 'test':
         from test import test
-        test()
+        test(visualize=args.visualize)
 
 if __name__ == '__main__':
     main()

--- a/src/robot_navigation_system/test.py
+++ b/src/robot_navigation_system/test.py
@@ -10,7 +10,7 @@ from dqn_agent import DQNAgent
 from visualization import NavigationVisualizer
 from config import Config
 
-def test():
+def test(visualize=None):
     config = Config()
     env = RobotNavigationEnv()
     agent = DQNAgent(config.STATE_SIZE, config.ACTION_SIZE)

--- a/src/robot_navigation_system/train.py
+++ b/src/robot_navigation_system/train.py
@@ -8,28 +8,35 @@ from dqn_agent import DQNAgent
 from visualization import NavigationVisualizer
 from config import Config
 
-def train():
+def train(episodes=None, visualize=None):
     config = Config()
-    
+
+    # 命令行参数覆盖配置
+    if episodes is not None:
+        config.EPISODES = episodes
+    if visualize is not None:
+        config.VISUALIZE = visualize
+
     # 创建结果目录
     os.makedirs(config.RESULT_DIR, exist_ok=True)
-    
+
     env = RobotNavigationEnv()
     agent = DQNAgent(config.STATE_SIZE, config.ACTION_SIZE)
     visualizer = NavigationVisualizer()
-    
+
     all_rewards = []
     all_distances = []
     all_lengths = []
-    
+
     print("=" * 60)
     print("开始训练DQN导航代理...")
     print(f"训练轮数: {config.EPISODES}")
     print(f"最大步数: {config.MAX_STEPS}")
     print(f"状态维度: {config.STATE_SIZE}")
     print(f"动作数量: {config.ACTION_SIZE}")
+    print(f"可视化: {'开启' if config.VISUALIZE else '关闭'}")
     print("=" * 60)
-    
+
     for episode in range(config.EPISODES):
         state = env.reset()
         total_reward = 0


### PR DESCRIPTION
修改概述: 修复robot_navigation_system模块的命令行参数逻辑bug

## 修改的详细描述
1. 修复 `--visualize` 参数bug：`action='store_true'` 搭配 `default=True` 导致参数永远为True，用户无法关闭可视化
2. 新增 `--no-visualize` 参数：支持用户通过命令行关闭可视化
3. 修复参数未传递问题：原代码解析了 `args.episodes` 和 `args.visualize` 但从未传给 `train()` 和 `test()`
4. `train()` 接收 `episodes` 和 `visualize` 参数，覆盖config默认值
5. `test()` 接收 `visualize` 参数

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python版本：Python 3.8+ / Anaconda
3. 测试场景：
   - `python main.py --help` → 参数说明正确显示
   - `python main.py --mode train --no-visualize` → 可视化关闭
   - `python main.py --mode train --visualize` → 可视化开启

## 运行效果
改进前：
- `--visualize` 参数无效，无论是否传入都为True
- `--episodes` 参数无效，解析后从未使用


- 可视化和训练轮数只能通过修改config.py源码控制

改进后：
- `--visualize` 默认关闭，用户可按需开启
- `--no-visualize` 可显式关闭
- `--episodes 100` 可直接控制训练轮数
- 无需修改源码即可调整训练参数
<img width="1338" height="304" alt="1d84843d-0ef9-4de8-8c32-00d8a1f2253c" src="https://github.com/user-attachments/assets/a929634e-5e60-4964-a3e6-a3dad309797f" />
