### PR TITLE
添加训练checkpoint保存与断点续训机制

### DIFF
--- a/src/robot_navigation_system/main.py
+++ b/src/robot_navigation_system/main.py
@@ -6,18 +6,19 @@ def main():
     parser.add_argument('--mode', type=str, default='train', choices=['train', 'test'],
                         help='运行模式: train（训练）或 test（测试）')
     parser.add_argument('--episodes', type=int, default=500, help='训练轮数')
-    parser.add_argument('--visualize', action='store_true', default=True, help='是否可视化')
-    
+    parser.add_argument('--visualize', action='store_true', default=False, help='是否可视化')
+    parser.add_argument('--no-visualize', dest='visualize', action='store_false', help='关闭可视化')
+
     args = parser.parse_args()
-    
+
     os.makedirs('./results', exist_ok=True)
-    
+
     if args.mode == 'train':
         from train import train
-        train()
+        train(episodes=args.episodes, visualize=args.visualize)
     elif args.mode == 'test':
         from test import test
-        test()
+        test(visualize=args.visualize)
 
 if __name__ == '__main__':
     main()

--- a/src/robot_navigation_system/test.py
+++ b/src/robot_navigation_system/test.py
@@ -10,7 +10,7 @@ from dqn_agent import DQNAgent
 from visualization import NavigationVisualizer
 from config import Config
 
-def test():
+def test(visualize=None):
     config = Config()
     env = RobotNavigationEnv()
     agent = DQNAgent(config.STATE_SIZE, config.ACTION_SIZE)

--- a/src/robot_navigation_system/train.py
+++ b/src/robot_navigation_system/train.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 import matplotlib
 matplotlib.use('Agg')  # 使用非交互式后端
 import matplotlib.pyplot as plt
@@ -8,29 +9,52 @@ from dqn_agent import DQNAgent
 from visualization import NavigationVisualizer
 from config import Config
 
-def train():
+def train(episodes=None, visualize=None):
     config = Config()
-    
+
+    # 命令行参数覆盖配置
+    if episodes is not None:
+        config.EPISODES = episodes
+    if visualize is not None:
+        config.VISUALIZE = visualize
+
     # 创建结果目录
     os.makedirs(config.RESULT_DIR, exist_ok=True)
-    
+
     env = RobotNavigationEnv()
     agent = DQNAgent(config.STATE_SIZE, config.ACTION_SIZE)
     visualizer = NavigationVisualizer()
-    
+
     all_rewards = []
     all_distances = []
     all_lengths = []
-    
+
+    start_episode = 0
+
+    # 尝试加载checkpoint续训
+    checkpoint_path = os.path.join(config.RESULT_DIR, 'checkpoint.pth')
+    if os.path.exists(checkpoint_path):
+        checkpoint = torch.load(checkpoint_path, map_location=agent.device)
+        agent.q_network.load_state_dict(checkpoint['model_state_dict'])
+        agent.target_network.load_state_dict(checkpoint['target_state_dict'])
+        agent.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+        agent.epsilon = checkpoint['epsilon']
+        start_episode = checkpoint['episode'] + 1
+        all_rewards = checkpoint.get('rewards', [])
+        all_distances = checkpoint.get('distances', [])
+        all_lengths = checkpoint.get('lengths', [])
+        print(f"从第 {start_episode} 轮恢复训练，epsilon={agent.epsilon:.4f}")
+
     print("=" * 60)
     print("开始训练DQN导航代理...")
     print(f"训练轮数: {config.EPISODES}")
+    print(f"起始轮次: {start_episode}")
     print(f"最大步数: {config.MAX_STEPS}")
     print(f"状态维度: {config.STATE_SIZE}")
     print(f"动作数量: {config.ACTION_SIZE}")
     print("=" * 60)
-    
-    for episode in range(config.EPISODES):
+
+    for episode in range(start_episode, config.EPISODES):
         state = env.reset()
         total_reward = 0
         distance_history = []
@@ -76,14 +100,35 @@ def train():
         if episode % config.PLOT_INTERVAL == 0 and config.VISUALIZE:
             visualizer.save_figure(f'navigation_episode_{episode}.png')
             print(f"  -> 保存导航截图: navigation_episode_{episode}.png")
-    
+
+        # 定期保存checkpoint
+        if (episode + 1) % 50 == 0:
+            checkpoint_path = os.path.join(config.RESULT_DIR, 'checkpoint.pth')
+            torch.save({
+                'episode': episode,
+                'model_state_dict': agent.q_network.state_dict(),
+                'target_state_dict': agent.target_network.state_dict(),
+                'optimizer_state_dict': agent.optimizer.state_dict(),
+                'epsilon': agent.epsilon,
+                'rewards': all_rewards,
+                'distances': all_distances,
+                'lengths': all_lengths,
+            }, checkpoint_path)
+            print(f"  -> Checkpoint已保存: 第 {episode + 1} 轮")
+
     print("=" * 60)
     print("训练完成！")
     print("=" * 60)
-    
-    # 保存模型
+
+    # 保存最终模型
     agent.save_model()
     print(f"模型已保存: dqn_navigation_model.pth")
+
+    # 清理checkpoint
+    checkpoint_path = os.path.join(config.RESULT_DIR, 'checkpoint.pth')
+    if os.path.exists(checkpoint_path):
+        os.remove(checkpoint_path)
+        print("训练完成，checkpoint已清理")
     
     # 绘制训练历史
     visualizer.plot_training_history(all_rewards, all_distances, all_lengths)


### PR DESCRIPTION
修改概述: 为DQN导航训练添加checkpoint保存机制，支持中断后断点续训

## 修改的详细描述
1. 每训练50轮自动保存checkpoint，包含模型权重、优化器状态、epsilon、训练历史
2. 训练启动时检测已有checkpoint，自动恢复训练进度
3. 训练完成后自动清理checkpoint文件
4. 修复main.py参数未传递给train()/test()的问题

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python版本：Python 3.8+ / Anaconda + PyTorch
3. 测试场景：
   - 运行100轮训练 → 第50轮和第100轮自动保存checkpoint
   - 训练完成后checkpoint被自动清理
   - 中断后重新运行 → 自动从checkpoint恢复训练

## 运行效果
改进前：
- 500轮训练中断后所有进度丢失，需要从头训练
- 无任何中间保存机制

改进后：
- 每50轮自动保存checkpoint到 results/checkpoint.pth
- 中断后重新运行自动检测并恢复：显示"从第 X 轮恢复训练"
- 训练完成后自动清理checkpoint，只保留最终模型
<img width="1418" height="654" alt="image" src="https://github.com/user-attachments/assets/b059361a-ce65-4632-9da8-634991d8b1bb" />
