### PR TITLE
改进车辆避障仿真指标报告

### DIFF
--- a/src/vehicle_movement_and_obstacle_avoidance/README.md
+++ b/src/vehicle_movement_and_obstacle_avoidance/README.md
@@ -23,3 +23,31 @@
 4. 安装依赖库：通过Python包管理工具安装所需核心依赖库，若需使用强化学习功能，额外安装对应的强化学习相关依赖库。
 
 5. 验证环境：运行简单的Python命令导入mujoco库，无报错则说明环境搭建完成。
+
+## 仿真指标统计与 CSV 报告
+
+本项目新增了无界面运行和仿真指标导出功能，便于在 PyCharm 终端或 CI 环境中复现实验结果。
+
+运行示例：
+
+```bash
+python qwer.py --headless --duration 8 --output-dir output --log-interval 1
+```
+
+参数说明：
+
+- `--headless`：不打开 MuJoCo viewer，直接运行仿真并输出数据。
+- `--duration`：仿真时长，单位为秒。
+- `--output-dir`：CSV 报告输出目录，默认值为 `output`。
+- `--log-interval`：终端状态打印间隔，单位为秒。
+
+运行结束后会生成 `output/simulation_metrics.csv`，包含每一步的车辆位置、速度、油门、转向角、让行状态、急刹状态、避障状态、最近障碍距离和两车距离等指标。终端会同步打印最小车距、平均速度、急刹次数和距离目标点的剩余距离。
+
+## 避障决策优化
+
+车辆避障逻辑在原有道路边界斥力和让行规则基础上，新增动态车辆斥力：
+
+- 当两车距离进入 `avoidance_distance` 范围时，根据距离和相对速度生成连续斥力。
+- 使用 `avoidance_active` 标记当前车辆是否处于主动避障状态。
+- 使用 `min_obstacle_distance` 记录最近动态障碍距离，方便在 CSV 报告中分析避障过程。
+- 急刹阈值拆分为独立的 `emergency_distance`，避免和普通避障距离混用。

--- a/src/vehicle_movement_and_obstacle_avoidance/qwer.py
+++ b/src/vehicle_movement_and_obstacle_avoidance/qwer.py
@@ -12,17 +12,106 @@
 
 import mujoco
 import mujoco.viewer
+import argparse
+import csv
 import numpy as np
 import threading
 import time
 import math
 from collections import deque
+from pathlib import Path
 
 # ==================== 共享数据结构 ====================
 car_states = {}
 state_lock = threading.Lock()
 simulation_running = True
 step_barrier = None
+
+
+class SimulationMetrics:
+    """Collect per-step vehicle metrics and export a CSV report."""
+
+    def __init__(self, output_dir="output"):
+        self.output_dir = Path(output_dir)
+        self.rows = []
+        self.min_distance = float("inf")
+        self.emergency_events = {1: 0, 2: 0}
+        self.last_emergency = {1: False, 2: False}
+
+    def record(self, step, sim_time, car1_ctrl, car2_ctrl):
+        with state_lock:
+            state1 = car_states.get(1, {}).copy()
+            state2 = car_states.get(2, {}).copy()
+
+        pos1 = state1.get("position", (0.0, 0.0))
+        pos2 = state2.get("position", (0.0, 0.0))
+        distance = math.hypot(pos1[0] - pos2[0], pos1[1] - pos2[1])
+        self.min_distance = min(self.min_distance, distance)
+
+        for ctrl in (car1_ctrl, car2_ctrl):
+            if ctrl.emergency_brake and not self.last_emergency[ctrl.car_id]:
+                self.emergency_events[ctrl.car_id] += 1
+            self.last_emergency[ctrl.car_id] = ctrl.emergency_brake
+
+        self.rows.append({
+            "step": step,
+            "time_sec": f"{sim_time:.3f}",
+            "car1_x": f"{pos1[0]:.4f}",
+            "car1_y": f"{pos1[1]:.4f}",
+            "car1_velocity": f"{state1.get('velocity', 0.0):.4f}",
+            "car1_throttle": f"{car1_ctrl.last_throttle:.4f}",
+            "car1_steer": f"{car1_ctrl.last_steer:.4f}",
+            "car1_yield": int(car1_ctrl.yield_flag),
+            "car1_emergency": int(car1_ctrl.emergency_brake),
+            "car1_avoidance": int(car1_ctrl.avoidance_active),
+            "car1_nearest_obstacle": f"{car1_ctrl.min_obstacle_distance:.4f}",
+            "car2_x": f"{pos2[0]:.4f}",
+            "car2_y": f"{pos2[1]:.4f}",
+            "car2_velocity": f"{state2.get('velocity', 0.0):.4f}",
+            "car2_throttle": f"{car2_ctrl.last_throttle:.4f}",
+            "car2_steer": f"{car2_ctrl.last_steer:.4f}",
+            "car2_yield": int(car2_ctrl.yield_flag),
+            "car2_emergency": int(car2_ctrl.emergency_brake),
+            "car2_avoidance": int(car2_ctrl.avoidance_active),
+            "car2_nearest_obstacle": f"{car2_ctrl.min_obstacle_distance:.4f}",
+            "distance_between_cars": f"{distance:.4f}",
+        })
+
+    def save(self):
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        csv_path = self.output_dir / "simulation_metrics.csv"
+        if not self.rows:
+            return csv_path
+
+        with csv_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(self.rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(self.rows)
+        return csv_path
+
+    def summary(self, car1_ctrl, car2_ctrl):
+        if not self.rows:
+            return {
+                "steps": 0,
+                "min_distance": 0.0,
+                "car1_avg_velocity": 0.0,
+                "car2_avg_velocity": 0.0,
+                "car1_emergency_events": 0,
+                "car2_emergency_events": 0,
+            }
+
+        car1_avg = sum(float(row["car1_velocity"]) for row in self.rows) / len(self.rows)
+        car2_avg = sum(float(row["car2_velocity"]) for row in self.rows) / len(self.rows)
+        return {
+            "steps": len(self.rows),
+            "min_distance": self.min_distance,
+            "car1_avg_velocity": car1_avg,
+            "car2_avg_velocity": car2_avg,
+            "car1_emergency_events": self.emergency_events[1],
+            "car2_emergency_events": self.emergency_events[2],
+            "car1_goal_distance": car1_ctrl.distance_to_goal(),
+            "car2_goal_distance": car2_ctrl.distance_to_goal(),
+        }
 
 
 # ==================== PID控制器（用于速度） ====================
@@ -61,16 +150,19 @@ class CarController:
         self.actuator_ids = actuator_ids
         self.sensor_ids = sensor_ids
         self.goal_pos = goal_pos  # 固定目标点 (x, y)
+        self.body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, f"car{car_id}")
 
         # 控制参数 - 速度减慢
         self.target_velocity = 1.5
 
         # 人工势场法参数 - 优化后的值
         self.att_gain = 1.0
-        self.rep_car_gain = 8.0          # 增加车辆斥力增益（已移除，保留不变）
+        self.rep_car_gain = 12.0         # 动态车辆斥力增益
         self.rep_wall_gain = 1.0          # 减小边界斥力强度
         self.rep_distance_threshold = 0.8 # 缩小作用范围
         self.safe_distance = 3.0          # 车辆间安全距离
+        self.emergency_distance = 0.45
+        self.avoidance_distance = 3.5
         self.max_steer = 0.4
 
         # 传感器方向（用于调试，未实际使用）
@@ -106,6 +198,8 @@ class CarController:
         self.yield_flag = False
         self.near_car = False
         self.emergency_brake = False
+        self.avoidance_active = False
+        self.min_obstacle_distance = 10.0
 
         # 当前控制输出
         self.last_throttle = 0.0
@@ -114,6 +208,11 @@ class CarController:
         # 速度索引（用于直接从qvel获取全局速度）
         # freejoint 速度维度：前3为线速度(x,y,z)，后3为角速度
         self.vel_start = 0 if car_id == 1 else 7  # car1从0开始，car2从7开始
+
+    def distance_to_goal(self):
+        state = car_states.get(self.car_id, {})
+        pos = state.get("position", (0.0, 0.0))
+        return math.hypot(self.goal_pos[0] - pos[0], self.goal_pos[1] - pos[1])
 
     def get_sensor_data(self):
         """读取传感器数据，返回字典，优先使用全局速度"""
@@ -144,8 +243,8 @@ class CarController:
     def update_state(self):
         """更新本车状态到共享字典"""
         start = 0 if self.car_id == 1 else 7
-        pos_xy = (self.data.qpos[start], self.data.qpos[start + 1])
-        quat = self.data.qpos[start + 3:start + 7]
+        pos_xy = (self.data.xpos[self.body_id][0], self.data.xpos[self.body_id][1])
+        quat = self.data.xquat[self.body_id]
         # 计算航向角（绕z轴）
         heading = math.atan2(2.0 * (quat[0] * quat[3] + quat[1] * quat[2]),
                              1.0 - 2.0 * (quat[2] * quat[2] + quat[3] * quat[3]))
@@ -159,7 +258,7 @@ class CarController:
 
     def compute_apf_steering(self, my_sensor, other_cars):
         """
-        人工势场法计算期望转向角（已移除两车之间的斥力）
+        人工势场法计算期望转向角，融合道路边界和动态车辆斥力。
         """
         my_state = car_states.get(self.car_id, {})
         my_pos = my_state.get('position', (0, 0))
@@ -172,18 +271,26 @@ class CarController:
         # 斥力
         F_rep_total = np.array([0.0, 0.0])
 
-        # 动态车辆斥力（已移除）
-        # for other_id, state in other_cars.items():
-        #     if other_id == self.car_id:
-        #         continue
-        #     other_pos = state.get('position', (0, 0))
-        #     dx = other_pos[0] - my_pos[0]
-        #     dy = other_pos[1] - my_pos[1]
-        #     dist = math.hypot(dx, dy)
-        #     if dist < self.safe_distance and dist > 0.1:
-        #         dir_vec = np.array([-dx, -dy]) / dist
-        #         mag = self.rep_car_gain / (dist * dist)
-        #         F_rep_total += mag * dir_vec
+        self.min_obstacle_distance = 10.0
+        self.avoidance_active = False
+
+        for other_id, state in other_cars.items():
+            if other_id == self.car_id:
+                continue
+
+            other_pos = state.get('position', (0, 0))
+            dx = other_pos[0] - my_pos[0]
+            dy = other_pos[1] - my_pos[1]
+            dist = math.hypot(dx, dy)
+            self.min_obstacle_distance = min(self.min_obstacle_distance, dist)
+
+            if 0.1 < dist < self.avoidance_distance:
+                dir_vec = np.array([-dx, -dy]) / dist
+                closing_speed = max(0.0, my_sensor.get('velocity', 0.0) - state.get('velocity', 0.0))
+                distance_scale = (self.avoidance_distance - dist) / self.avoidance_distance
+                mag = self.rep_car_gain * distance_scale * (1.0 + 0.35 * closing_speed) / max(dist, 0.2)
+                F_rep_total += mag * dir_vec
+                self.avoidance_active = True
 
         # 道路边界斥力
         # 左边界
@@ -231,7 +338,7 @@ class CarController:
         self.near_car = any(
             other_id != self.car_id and
             math.hypot(other_cars[other_id]['position'][0] - my_pos[0],
-                       other_cars[other_id]['position'][1] - my_pos[1]) < 3.0
+                       other_cars[other_id]['position'][1] - my_pos[1]) < self.safe_distance
             for other_id in other_cars
         )
         # 简单的让行规则：ID大的让行
@@ -239,10 +346,10 @@ class CarController:
 
         # 紧急刹车 - 缩小距离阈值
         front_dist = my_sensor.get('front', 10.0)
-        self.emergency_brake = front_dist < 0.5 or any(
+        self.emergency_brake = front_dist < self.emergency_distance or any(
             other_id != self.car_id and
             math.hypot(other_cars[other_id]['position'][0] - my_pos[0],
-                       other_cars[other_id]['position'][1] - my_pos[1]) < 0.5
+                       other_cars[other_id]['position'][1] - my_pos[1]) < self.emergency_distance
             for other_id in other_cars
         )
 
@@ -428,12 +535,80 @@ def create_road_xml():
 
 
 # ==================== 主仿真函数 ====================
-def multi_car_simulation():
+def build_arg_parser():
+    parser = argparse.ArgumentParser(description="MuJoCo vehicle movement and obstacle avoidance simulation")
+    parser.add_argument("--headless", action="store_true", help="run without MuJoCo viewer")
+    parser.add_argument("--duration", type=float, default=12.0, help="simulation duration in seconds")
+    parser.add_argument("--output-dir", default="output", help="directory for CSV metric reports")
+    parser.add_argument("--log-interval", type=float, default=2.0, help="console log interval in seconds")
+    return parser
+
+
+def apply_control_outputs(data, actuator_ids, car1_ctrl, car2_ctrl):
+    data.ctrl[actuator_ids[1]['throttle_left']] = car1_ctrl.last_throttle
+    data.ctrl[actuator_ids[1]['throttle_right']] = car1_ctrl.last_throttle
+    data.ctrl[actuator_ids[1]['steer_left']] = car1_ctrl.last_steer
+    data.ctrl[actuator_ids[1]['steer_right']] = car1_ctrl.last_steer
+
+    data.ctrl[actuator_ids[2]['throttle_left']] = car2_ctrl.last_throttle
+    data.ctrl[actuator_ids[2]['throttle_right']] = car2_ctrl.last_throttle
+    data.ctrl[actuator_ids[2]['steer_left']] = car2_ctrl.last_steer
+    data.ctrl[actuator_ids[2]['steer_right']] = car2_ctrl.last_steer
+
+
+def update_shared_positions(model, data):
+    car1_body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "car1")
+    car2_body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "car2")
+    with state_lock:
+        car_states[1]['position'] = (data.xpos[car1_body][0], data.xpos[car1_body][1])
+        quat1 = data.xquat[car1_body]
+        car_states[1]['heading'] = math.atan2(
+            2.0 * (quat1[0] * quat1[3] + quat1[1] * quat1[2]),
+            1.0 - 2.0 * (quat1[2] * quat1[2] + quat1[3] * quat1[3])
+        )
+        car_states[2]['position'] = (data.xpos[car2_body][0], data.xpos[car2_body][1])
+        quat2 = data.xquat[car2_body]
+        car_states[2]['heading'] = math.atan2(
+            2.0 * (quat2[0] * quat2[3] + quat2[1] * quat2[2]),
+            1.0 - 2.0 * (quat2[2] * quat2[2] + quat2[3] * quat2[3])
+        )
+
+
+def print_runtime_status(step, car1_ctrl, car2_ctrl):
+    with state_lock:
+        v1 = car_states[1]['velocity']
+        v2 = car_states[2]['velocity']
+    print(
+        f"Step {step}: "
+        f"Car1 vel={v1:.2f} yield={car1_ctrl.yield_flag} avoid={car1_ctrl.avoidance_active} emerg={car1_ctrl.emergency_brake}, "
+        f"Car2 vel={v2:.2f} yield={car2_ctrl.yield_flag} avoid={car2_ctrl.avoidance_active} emerg={car2_ctrl.emergency_brake}"
+    )
+
+
+def print_metric_summary(summary, csv_path):
+    print("\n=== Simulation Metrics Summary ===")
+    print(f"CSV report: {csv_path}")
+    print(f"Steps recorded: {summary['steps']}")
+    print(f"Minimum distance between cars: {summary['min_distance']:.3f} m")
+    print(f"Car1 average velocity: {summary['car1_avg_velocity']:.3f} m/s")
+    print(f"Car2 average velocity: {summary['car2_avg_velocity']:.3f} m/s")
+    print(f"Car1 emergency brake events: {summary['car1_emergency_events']}")
+    print(f"Car2 emergency brake events: {summary['car2_emergency_events']}")
+    print(f"Car1 distance to goal: {summary['car1_goal_distance']:.3f} m")
+    print(f"Car2 distance to goal: {summary['car2_goal_distance']:.3f} m")
+
+
+def multi_car_simulation(args=None):
     global simulation_running, step_barrier
+    args = args or build_arg_parser().parse_args()
+    simulation_running = True
+    car_states.clear()
     xml = create_road_xml()
     model = mujoco.MjModel.from_xml_string(xml)
     data = mujoco.MjData(model)
     mujoco.mj_forward(model, data)
+    max_steps = max(1, int(args.duration / model.opt.timestep))
+    metrics = SimulationMetrics(args.output_dir)
 
     actuator_ids = {1: {}, 2: {}}
     sensor_ids = {1: {}, 2: {}}
@@ -469,8 +644,8 @@ def multi_car_simulation():
 
     # 正确初始化共享状态中的航向角（关键修复）
     with state_lock:
-        car_states[1] = {'position': (data.qpos[0], data.qpos[1]), 'heading': 0, 'velocity': 0}
-        car_states[2] = {'position': (data.qpos[7], data.qpos[8]), 'heading': 0, 'velocity': 0}
+        car_states[1] = {'position': (data.xpos[car1_ctrl.body_id][0], data.xpos[car1_ctrl.body_id][1]), 'heading': 0, 'velocity': 0}
+        car_states[2] = {'position': (data.xpos[car2_ctrl.body_id][0], data.xpos[car2_ctrl.body_id][1]), 'heading': 0, 'velocity': 0}
     car1_ctrl.update_state()
     car2_ctrl.update_state()
 
@@ -486,13 +661,13 @@ def multi_car_simulation():
                     break
                 ctrl.control_step()
                 step_barrier.wait()
+            except threading.BrokenBarrierError:
+                break
             except Exception as e:
                 print(f"控制器线程 {ctrl.car_id} 发生异常: {e}")
                 import traceback
                 traceback.print_exc()
                 simulation_running = False
-                break
-            except threading.BrokenBarrierError:
                 break
 
     t1 = threading.Thread(target=controller_loop, args=(car1_ctrl,))
@@ -501,55 +676,42 @@ def multi_car_simulation():
     t2.start()
 
     try:
-        with mujoco.viewer.launch_passive(model, data) as viewer:
-            viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
-            viewer.cam.trackbodyid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "car1")
-            viewer.cam.distance = 10.0
-            viewer.cam.elevation = -30
-            viewer.cam.azimuth = 90
-
-            step = 0
-            last_display = time.time()
-            while viewer.is_running() and simulation_running:
+        step = 0
+        last_display = time.time()
+        if args.headless:
+            while simulation_running and step < max_steps:
                 step_barrier.wait()
-                # 应用控制
-                data.ctrl[actuator_ids[1]['throttle_left']] = car1_ctrl.last_throttle
-                data.ctrl[actuator_ids[1]['throttle_right']] = car1_ctrl.last_throttle
-                data.ctrl[actuator_ids[1]['steer_left']] = car1_ctrl.last_steer
-                data.ctrl[actuator_ids[1]['steer_right']] = car1_ctrl.last_steer
-
-                data.ctrl[actuator_ids[2]['throttle_left']] = car2_ctrl.last_throttle
-                data.ctrl[actuator_ids[2]['throttle_right']] = car2_ctrl.last_throttle
-                data.ctrl[actuator_ids[2]['steer_left']] = car2_ctrl.last_steer
-                data.ctrl[actuator_ids[2]['steer_right']] = car2_ctrl.last_steer
-
+                apply_control_outputs(data, actuator_ids, car1_ctrl, car2_ctrl)
                 mujoco.mj_step(model, data)
-
-                # 更新共享状态（航向角）
-                with state_lock:
-                    car_states[1]['position'] = (data.qpos[0], data.qpos[1])
-                    quat1 = data.qpos[3:7]
-                    car_states[1]['heading'] = math.atan2(2.0 * (quat1[0] * quat1[3] + quat1[1] * quat1[2]),
-                                                          1.0 - 2.0 * (quat1[2] * quat1[2] + quat1[3] * quat1[3]))
-                    car_states[2]['position'] = (data.qpos[7], data.qpos[8])
-                    quat2 = data.qpos[10:14]
-                    car_states[2]['heading'] = math.atan2(2.0 * (quat2[0] * quat2[3] + quat2[1] * quat2[2]),
-                                                          1.0 - 2.0 * (quat2[2] * quat2[2] + quat2[3] * quat2[3]))
-
+                update_shared_positions(model, data)
                 step_barrier.wait()
-                viewer.sync()
                 step += 1
+                metrics.record(step, step * model.opt.timestep, car1_ctrl, car2_ctrl)
 
-                if time.time() - last_display > 2.0:
-                    v1 = car_states[1]['velocity']
-                    v2 = car_states[2]['velocity']
-                    y1 = car1_ctrl.yield_flag
-                    y2 = car2_ctrl.yield_flag
-                    e1 = car1_ctrl.emergency_brake
-                    e2 = car2_ctrl.emergency_brake
-                    print(
-                        f"Step {step}: Car1 vel={v1:.2f} yield={y1} emerg={e1}, Car2 vel={v2:.2f} yield={y2} emerg={e2}")
+                if time.time() - last_display > args.log_interval:
+                    print_runtime_status(step, car1_ctrl, car2_ctrl)
                     last_display = time.time()
+        else:
+            with mujoco.viewer.launch_passive(model, data) as viewer:
+                viewer.cam.type = mujoco.mjtCamera.mjCAMERA_TRACKING
+                viewer.cam.trackbodyid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "car1")
+                viewer.cam.distance = 10.0
+                viewer.cam.elevation = -30
+                viewer.cam.azimuth = 90
+
+                while viewer.is_running() and simulation_running and step < max_steps:
+                    step_barrier.wait()
+                    apply_control_outputs(data, actuator_ids, car1_ctrl, car2_ctrl)
+                    mujoco.mj_step(model, data)
+                    update_shared_positions(model, data)
+                    step_barrier.wait()
+                    viewer.sync()
+                    step += 1
+                    metrics.record(step, step * model.opt.timestep, car1_ctrl, car2_ctrl)
+
+                    if time.time() - last_display > args.log_interval:
+                        print_runtime_status(step, car1_ctrl, car2_ctrl)
+                        last_display = time.time()
 
     except KeyboardInterrupt:
         print("用户中断")
@@ -562,6 +724,8 @@ def multi_car_simulation():
             t2.join()
         except:
             pass
+        csv_path = metrics.save()
+        print_metric_summary(metrics.summary(car1_ctrl, car2_ctrl), csv_path)
         print("仿真结束")
 
 


### PR DESCRIPTION
修改概述: 改进 vehicle_movement_and_obstacle_avoidance 项目的仿真指标统计与避障决策逻辑，新增 CSV 报告输出，并让双车避障过程更便于复现和分析。

## 修改的详细描述
1. 新增 `SimulationMetrics` 仿真指标统计模块，逐步记录两车位置、速度、油门、转向角、让行状态、急刹状态、避障状态、最近障碍距离和两车距离，并在运行结束后导出 `output/simulation_metrics.csv`。
2. 新增命令行参数支持，包括 `--headless`、`--duration`、`--output-dir` 和 `--log-interval`，可在不打开 MuJoCo viewer 的情况下运行仿真并生成报告。
3. 优化避障决策逻辑，恢复并增强动态车辆斥力，根据两车距离和相对速度生成连续斥力；新增 `avoidance_active` 和 `min_obstacle_distance` 指标。
4. 将车辆位置统计改为使用 MuJoCo body 世界坐标 `xpos`，避免直接读取 `qpos` 导致车辆位置记录不准确的问题。
5. 更新 README，补充无界面运行方式、CSV 报告说明和动态避障逻辑说明。

## 经过了什么样的测试?
1. 操作系统：Windows 10 / Windows 11，PowerShell / PyCharm 终端
2. Python版本等：Python 3.10，mujoco 3.8.0，numpy
3. 测试命令：
   - `D:\Python\python.exe -m py_compile qwer.py`
   - `D:\Python\python.exe qwer.py --help`
   - `D:\Python\python.exe qwer.py --headless --duration 8 --output-dir output --log-interval 1`

## 运行效果
<img width="1716" height="1323" alt="image" src="https://github.com/user-attachments/assets/91e29856-de50-4acc-899f-df9305f34cd3" />
