### PR TITLE
为setup_tool增加演示模式配置

### DIFF
--- a/src/setup_tool/main.py
+++ b/src/setup_tool/main.py
@@ -105,6 +105,12 @@ def parse_args():
         default="normal",
         help="Set demo speed: fast, normal, or slow",
     )
+    parser.add_argument(
+        "--mode",
+        choices=["basic", "full"],
+        default="full",
+        help="Set demo mode: basic or full",
+    )
     return parser.parse_args()
 
 
@@ -126,11 +132,12 @@ def main():
    print("  This is a demonstration of the progress display features.")
    print("  No actual downloads or installations will be performed.")
    print(f"  Demo speed: {args.speed}")
+   print(f"  Demo mode: {args.mode}")
    print("=" * 80)
    print()
 
 
-   steps = [
+   full_steps = [
         {
             "description": "Checking hutb_downloader.exe",
             "actions": [
@@ -217,6 +224,19 @@ def main():
             ],
         },
     ]
+   
+   basic_steps = [
+        full_steps[0],
+        full_steps[2],
+        full_steps[6],
+        full_steps[8],
+        full_steps[10],
+    ]
+   
+   if args.mode == "basic":
+        steps = basic_steps
+   else:
+        steps = full_steps
 
    demo = ProgressDemo(total_steps=len(steps))
 


### PR DESCRIPTION
修改概述：

无对应 issue，本次为 setup_tool 模块演示模式配置增强。

## 修改的详细描述
1. 为 `src/setup_tool/main.py` 增加了命令行参数 `--mode`。
2. 支持 `basic` 和 `full` 两种演示模式。
3. 在不改变原有完整演示流程的前提下，使 demo 可以根据不同场景选择不同的步骤集合，提升了灵活性与复用性。

## 经过了什么样的测试？
1. 操作系统：Windows 10
2. 使用 Git Bash 和 VS Code 完成修改
3. 运行 `python src/setup_tool/main.py --mode full --speed fast` 和 `python src/setup_tool/main.py --mode basic --speed fast` 进行了验证
4. 确认修改后代码可以正常保存、提交和推送

## 运行效果
本次修改为功能增强，增加了演示模式配置，未改变原有完整流程逻辑。
