### PR TITLE
feat: 完善碰撞数据集信息记录

### DIFF
--- a/src/drone_flight_sim/collision_data_collector.py
+++ b/src/drone_flight_sim/collision_data_collector.py
@@ -24,8 +24,15 @@ class CollisionDataCollector:
         self.output_dir = output_dir
         self.depth_dir = os.path.join(output_dir, "depth")
         self.labels_file = os.path.join(output_dir, "labels.csv")
-        
+
         self._create_directories()
+        
+        # 如果 labels.csv 不存在，则创建并写入表头
+        if not os.path.exists(self.labels_file):
+            with open(self.labels_file, 'w') as f:
+                f.write("filename,label,risk,min_depth,mean_depth,x,y,z\n")
+
+        
         
         self.client = airsim.MultirotorClient()
         self.client.confirmConnection()
@@ -75,8 +82,8 @@ class CollisionDataCollector:
             risk_name = "safe" if self.current_label == 0 else "danger"
             with open(self.labels_file, 'a') as f:
                 f.write(f"{filename},{self.current_label},{risk_name},"
-                        f"{min_depth:.2f},{mean_depth:.2f},{pos.x_val:.1f},{pos.y_val:.1f}\n")
-            
+                        f"{min_depth:.2f},{mean_depth:.2f},"
+                        f"{pos.x_val:.1f},{pos.y_val:.1f},{pos.z_val:.1f}\n")
             self.sample_count += 1
             print(f"✅ 样本 {self.sample_count}: {filename} (深度:{min_depth:.1f}m)")
             return True


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

## 修改概述
完善 collision_data_collector.py 文件，使采集的数据更完整

## 修改概述
1. 为 collision_data_collector.py 增加 CSV 表头
2. 在 labels.csv 中新增无人机 z 轴高度信息记录

## 修改的详细描述
1. 在初始化时，如果 labels.csv 不存在，则创建并写入表头：
   "filename,label,risk,min_depth,mean_depth,x,y,z"
2. 在 capture_sample 方法中，将无人机位置 z 值写入 CSV
3. 保证采集数据更规范，方便后续深度学习模型训练

## 经过了什么样的测试?
1. 操作系统: Windows/macOS/Linux (根据你本地环境写)
2. Python 版本: 3.8
3. 通过按键操作 C 和 P 采集样本，检查 depth 文件夹和 labels.csv 中是否生成数据

## 运行效果
- labels.csv 文件增加表头
- 采集数据时，每条样本记录包含 x, y, z 三个坐标
- collision_dataset/depth/ 下生成对应深度图
<img width="824" height="287" alt="image" src="https://github.com/user-attachments/assets/9cab92e8-6b7b-4096-8c45-26aba02e3de9" />
