### PR TITLE
移除drone_perception模块的sklearn依赖

### DIFF
--- a/src/drone_perception/Data_classfication.py
+++ b/src/drone_perception/Data_classfication.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms, models
-from sklearn.metrics import accuracy_score
+
 import matplotlib.pyplot as plt
 
 def split_dataset(dataset_path, train_dir, test_dir, split_ratio=0.8):
@@ -293,7 +293,7 @@ def train_model(model, train_loader, test_loader, epochs, patience=5):
                 all_preds.extend(preds.cpu().numpy())
                 all_labels.extend(labels.cpu().numpy())
         
-        accuracy = accuracy_score(all_labels, all_preds)
+        accuracy = np.mean(np.array(all_labels) == np.array(all_preds))
         val_accuracies.append(accuracy)
         
         print(f'Epoch [{epoch+1}/{epochs}], Loss: {epoch_loss:.4f}, Accuracy: {accuracy:.4f}')

--- a/src/drone_perception/image_classification.py
+++ b/src/drone_perception/image_classification.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 from torchvision import transforms, models
-from sklearn.metrics import accuracy_score
+
 import matplotlib.pyplot as plt
 
 # 设置设备
@@ -236,7 +236,7 @@ def train_model(model, train_loader, test_loader, epochs, patience=5):
                 all_labels.extend(labels.cpu().numpy())
         
         # 计算准确率
-        accuracy = accuracy_score(all_labels, all_preds)
+        accuracy = np.mean(np.array(all_labels) == np.array(all_preds))
         val_accuracies.append(accuracy)
         
         print(f'Epoch [{epoch+1}/{epochs}], Loss: {epoch_loss:.4f}, Accuracy: {accuracy:.4f}')

--- a/src/drone_perception/main.py
+++ b/src/drone_perception/main.py
@@ -215,8 +215,7 @@ def train_pytorch_model():
                 all_preds.extend(preds.cpu().numpy())
                 all_labels.extend(labels.cpu().numpy())
         
-        from sklearn.metrics import accuracy_score
-        accuracy = accuracy_score(all_labels, all_preds)
+        accuracy = np.mean(np.array(all_labels) == np.array(all_preds))
         val_accuracies.append(accuracy)
         
         logger.info(f'Epoch [{epoch+1}/{epochs}], Loss: {epoch_loss:.4f}, Accuracy: {accuracy:.4f}')


### PR DESCRIPTION
修改概述
移除 drone_perception 模块对 sklearn.metrics.accuracy_score 的依赖，用纯numpy等价实现替代。
修改的详细描述
修改前： 3个文件分别通过 from sklearn.metrics import accuracy_score 导入sklearn，再用 accuracy_score(all_labels, all_preds) 计算准确率。sklearn仅用于这一个函数调用。
修改后： 移除所有sklearn导入，替换为 np.mean(np.array(all_labels) == np.array(all_preds))。3个文件均已导入numpy，无需新增依赖。
涉及文件：
• src/drone_perception/Data_classfication.py — 移除导入 + 替换计算（第11行、第296行）
• src/drone_perception/image_classification.py — 移除导入 + 替换计算（第9行、第239行）
• src/drone_perception/main.py — 移除局部导入 + 替换计算（第218-219行）
经过了什么样的测试？
• 代码审查：np.mean(labels == preds) 与 accuracy_score(labels, preds) 数学等价，均返回浮点数准确率
• 无新增依赖，所有文件已有 import numpy as np
运行效果
• 减少了一个外部依赖（sklearn），降低安装体积和依赖复杂度
• 计算结果完全一致，无功能变化