### PR TITLE
修复GMM中重复代码导致的收敛曲线和指标错误

### DIFF
--- a/src/chap11_gaussian_mixture/GMM.py
+++ b/src/chap11_gaussian_mixture/GMM.py
@@ -177,46 +177,37 @@ class GaussianMixtureModel:
         self.sigma = np.array([np.eye(n_features) for _ in range(self.n_components)])
 
         log_likelihood = -np.inf
-        
+
         log_pi = np.log(self.pi)
-        log_likelihood = -np.inf
-        
-        log_pi = np.log(self.pi)
-        
-        for iter in range(self.max_iter):
+
+        for iteration in range(self.max_iter):
             if self.n_jobs != 1:
                 log_prob = self._log_gaussian_parallel(X, self.mu, self.sigma)
             else:
                 log_prob = self._log_gaussian_batch(X, self.mu, self.sigma)
             log_prob += log_pi[np.newaxis, :]
-            
+
             log_prob_sum = logsumexp(log_prob, axis=1, keepdims=True)
-            
+
             gamma = np.exp(log_prob - log_prob_sum)
 
             Nk, new_mu, new_sigma = self._compute_statistics_vectorized(X, gamma)
-            Nk, new_mu, new_sigma = self._compute_statistics_vectorized(X, gamma)
-            
+
             self.pi = Nk / n_samples
             log_pi = np.log(self.pi)
-            
+
             current_log_likelihood = np.sum(log_prob_sum)
             self.log_likelihoods.append(current_log_likelihood)
-            log_pi = np.log(self.pi)
-            
-            current_log_likelihood = np.sum(log_prob_sum)
-            self.log_likelihoods.append(current_log_likelihood)
-            
-            if iter > 0 and abs(current_log_likelihood - log_likelihood) < self.tol:
+
+            if iteration > 0 and abs(current_log_likelihood - log_likelihood) < self.tol:
                 break
-                
+
             log_likelihood = current_log_likelihood
-            log_likelihood = current_log_likelihood
-            
+
             self.mu = new_mu
             self.sigma = new_sigma
-        
-        self.n_iters_ = iter + 1
+
+        self.n_iters_ = iteration + 1
         self.labels_ = np.argmax(gamma, axis=1)
         
         self._compute_aic_bic(X)
@@ -330,7 +321,7 @@ class GaussianMixtureModel:
         if sign <= 0:  # 行列式非正（理论上协方差矩阵应是正定的）
             # 添加一个小的对角扰动项（单位矩阵乘以1e-6）
             # 确保矩阵可逆且正定，提高数值稳定性
-            sigma += np.eye(n_features) * 1e-6  # 正则化处理
+            sigma = sigma + np.eye(n_features) * 1e-6  # 正则化处理
             
             # 重新计算调整后的协方差矩阵的行列式
             sign, logdet = np.linalg.slogdet(sigma)


### PR DESCRIPTION
修改概述
修复 chap11_gaussian_mixture/GMM.py 中 fit() 方法的重复代码行和协方差矩阵就地变异bug。
修改的详细描述
Bug 1 — 重复代码导致指标错误（严重）： fit() 方法中6处重复行，最关键的后果是 self.log_likelihoods.append() 每次迭代被执行两次，导致：
• 收敛曲线每个值出现两次（曲线呈阶梯状）
• n_iters_ 被虚增约2倍
• BIC/AIC 计算使用了错误的迭代次数
Bug 2 — 无效重复计算： _compute_statistics_vectorized() 每次迭代被调用两次，浪费CPU。
Bug 3 — sigma就地变异： _log_gaussian() 中 sigma += np.eye(...) 直接修改调用方的 self.sigma[k]，导致正则化项在多次迭代中不断叠加。
修复方式：
• 删除全部重复行，每个操作只执行一次
• sigma += 改为 sigma = sigma +（创建副本，不修改原数组）
• 循环变量 iter 改为 iteration（避免遮蔽内置函数）
涉及文件： src/chap11_gaussian_mixture/GMM.py（仅1个文件）
经过了什么样的测试？
运行 python GMM.py --no-show --n-trials 5 验证：
• 修复前：收敛曲线呈阶梯状（每个值重复），迭代次数虚高
• 修复后：收敛曲线平滑，迭代次数正确（k-means++ 仅需约11轮收敛）
• BIC正确选择 k=3（与生成数据的3个高斯成分一致）
运行效果
<img width="1384" height="683" alt="bic_model_selection" src="https://github.com/user-attachments/assets/a6a56610-4688-478f-bb4a-622c3b79d790" />
<img width="2084" height="690" alt="cluster_comparison" src="https://github.com/user-attachments/assets/122bc66e-f50a-4ca7-ab21-72a4a36216b7" />
<img width="2084" height="690" alt="comparison_benchmark" src="https://github.com/user-attachments/assets/edacd43b-c88d-4d0b-b7c8-28a07e679e29" />
<img width="1664" height="553" alt="convergence_comparison" src="https://github.com/user-attachments/assets/c3e85835-e347-4b90-9d91-37c046fc323e" />

