### PR TITLE
新增协方差类型支持与异常检测功能

### DIFF
--- a/docs/chap11_gaussian_mixture/README.md
+++ b/docs/chap11_gaussian_mixture/README.md
@@ -97,6 +97,11 @@ $$BIC = k \cdot \ln(n) - 2\ln(L)$$
 | 向量化 E 步计算 | ❌ | ✅ |
 | 向量化 M 步计算 | ❌ | ✅ |
 | 多线程并行计算 | ❌ | ✅ |
+| 完整协方差 (full) | ✅ | ✅ |
+| 共享协方差 (tied) | ❌ | ✅ |
+| 对角协方差 (diagonal) | ❌ | ✅ |
+| 球面协方差 (spherical) | ❌ | ✅ |
+| 异常检测功能 | ❌ | ✅ |
 
 ---
 
@@ -226,6 +231,63 @@ def _log_gaussian_parallel(self, X, mu, sigma):
 - 在多核 CPU 上可获得近线性加速比
 - 特别适合大规模数据和多成分场景
 
+### 4.6 协方差类型扩展
+
+支持四种协方差类型，适用于不同的数据分布特性：
+
+| 协方差类型 | 参数化形式 | 参数数量 | 适用场景 |
+|---|---|---|---|
+| `full` | 每个成分独立的完整协方差矩阵 | k * d*(d+1)/2 | 数据各维度有复杂相关性 |
+| `tied` | 所有成分共享同一个协方差矩阵 | d*(d+1)/2 | 各类别分布形状相似 |
+| `diagonal` | 每个成分独立的对角协方差 | k * d | 维度间独立，计算高效 |
+| `spherical` | 每个成分只有一个标量方差 | k | 球形分布，参数最少 |
+
+**协方差类型选择建议**：
+- 数据维度高、样本量有限 → `diagonal` 或 `spherical`（减少过拟合）
+- 各类别分布相似 → `tied`（共享协方差）
+- 需要捕捉复杂相关性 → `full`（完整协方差）
+
+### 4.7 异常检测扩展
+
+基于密度估计的异常检测功能，可识别远离聚类中心的离群点：
+
+**核心方法**：
+
+| 方法 | 功能 |
+|---|---|
+| `predict_proba(X)` | 预测样本属于各高斯成分的后验概率 |
+| `score_samples(X)` | 计算样本的对数概率密度（异常分数） |
+| `detect_anomalies(X, contamination=0.05)` | 检测异常样本 |
+| `plot_anomaly_score(X)` | 可视化异常检测结果 |
+
+**使用示例**：
+```python
+# 训练模型
+gmm = GaussianMixtureModel(n_components=3)
+gmm.fit(X)
+
+# 检测异常（5%异常比例）
+is_anomaly, scores, threshold = gmm.detect_anomalies(X_test, contamination=0.05)
+
+# 可视化结果
+gmm.plot_anomaly_score(X_test, save_path='anomaly.png')
+```
+
+**异常检测原理**：
+- 利用 GMM 拟合数据的概率密度分布
+- 对数概率密度低的样本被判定为异常
+- 通过 `contamination` 参数控制异常比例
+
+**测试结果**：
+```
+异常检测结果:
+  真实异常数: 25
+  检测异常数: 27
+  精确率: 0.8519
+  召回率: 0.9200
+  F1分数: 0.8846
+```
+
 ---
 
 ## 5. 系统运行效果
@@ -259,6 +321,8 @@ python GMM.py --n-samples 1000 --n-components 3 --max-iter 100 --n-trials 50 --o
 | `--max-iter` | int | 100 | 最大迭代次数 |
 | `--tol` | float | 1e-6 | 收敛阈值 |
 | `--n-trials` | int | 50 | 对比实验重复次数 |
+| `--n-jobs` | int | 1 | 并行计算线程数（-1表示使用所有CPU核心） |
+| `--covariance-type` | str | full | 协方差类型：full/tied/diagonal/spherical |
 | `--out-dir` | str | outputs | 输出目录 |
 | `--no-show` | flag | - | 不弹出图像窗口 |
 
@@ -272,6 +336,7 @@ python GMM.py --n-samples 1000 --n-components 3 --max-iter 100 --n-trials 50 --o
 | `cluster_comparison.png` | 聚类结果散点图对比 |
 | `convergence_comparison.png` | EM 收敛曲线对比 |
 | `bic_model_selection.png` | BIC/AIC 模型选择曲线 |
+| `anomaly_detection.png` | 异常检测结果可视化 |
 | `iteration_log.csv` | 迭代对数似然日志 |
 | `bic_aic_log.csv` | BIC/AIC 模型选择日志 |
 

--- a/src/chap11_gaussian_mixture/GMM.py
+++ b/src/chap11_gaussian_mixture/GMM.py
@@ -115,15 +115,19 @@ def logsumexp(log_p, axis=1, keepdims=False):
     # 计算修正后的指数和（处理-inf输入）
     # 安全计算指数和：先减去最大值，再计算指数
     safe_log_p = np.where(np.isneginf(log_p), -np.inf, log_p - max_val)     # 安全调整对数概率
-    sum_exp = np.sum(np.exp(safe_log_p), axis = axis, keepdims = keepdims)  # 计算调整后的指数和
+    sum_exp = np.sum(np.exp(safe_log_p), axis = axis, keepdims = True)      # 始终保持维度，便于后续计算
     
     # 计算最终结果
     result = max_val + np.log(sum_exp)
     
+    # 根据keepdims参数调整形状
+    if not keepdims:
+        result = result.squeeze(axis=axis)
+    
     # 处理全-inf输入的特殊case
-    if np.any(np.isneginf(log_p)) and not np.any(np.isfinite(log_p)):       # 判断是否所有有效值都是-inf
-        result = max_val.copy() if keepdims else max_val.squeeze(axis = axis) # 根据keepdims参数的值返回max_val的适当形式
-    return result                                                           # 返回处理后的结果，保持与正常情况相同的接口
+    if np.any(np.isneginf(log_p)) and not np.any(np.isfinite(log_p)):
+        result = max_val.copy() if keepdims else max_val.squeeze(axis=axis)
+    return result
 
 # 高斯混合模型类
 class GaussianMixtureModel:
@@ -134,22 +138,55 @@ class GaussianMixtureModel:
         max_iter: int, EM算法最大迭代次数 (默认=100)
         tol: float, 收敛阈值 (默认=1e-6)
         random_state: int, 随机种子 (可选)
+        init: str, 初始化策略：'random'（随机）或 'kmeans++'（智能距离权重采样）
         n_jobs: int, 并行计算使用的线程数 (默认=1，即不并行；-1表示使用所有CPU核心)
+        covariance_type: str, 协方差类型：'full'（完整协方差）、'tied'（共享协方差）、
+                         'diagonal'（对角协方差）、'spherical'（球面协方差）(默认='full')
     """
-    def __init__(self, n_components = 3, max_iter = 100, tol = 1e-6, random_state = None, init = 'random', n_jobs = 1):
+    def __init__(self, n_components = 3, max_iter = 100, tol = 1e-6, random_state = None, 
+                 init = 'random', n_jobs = 1, covariance_type = 'full'):
         # 初始化模型参数
         self.n_components = n_components  # 高斯分布数量
         self.max_iter = max_iter          # EM算法最大迭代次数
         self.tol = tol                    # 收敛阈值
         self.init = init                  # 初始化策略：'random'（随机）或 'kmeans++'（智能距离权重采样）
         self.n_jobs = n_jobs              # 并行线程数
+        self.covariance_type = covariance_type.lower()  # 协方差类型
         self.log_likelihoods = []         # 存储每轮迭代的对数似然值
         self.n_iters_ = 0                 # 实际收敛所用的迭代次数
         self.aic_ = None                  # AIC 值（训练后计算）
         self.bic_ = None                  # BIC 值（训练后计算）
 
+        # 验证协方差类型
+        if self.covariance_type not in ['full', 'tied', 'diagonal', 'spherical']:
+            raise ValueError(f"无效的协方差类型: {covariance_type}，可选值: 'full', 'tied', 'diagonal', 'spherical'")
+
         # 初始化随机数生成器（使用 numpy 新式 Generator，线程安全且可重复）
         self.rng = np.random.default_rng(random_state)
+
+    def _init_covariance(self, n_features):
+        """根据协方差类型初始化协方差矩阵
+        
+        参数:
+            n_features: 特征维度
+            
+        返回:
+            sigma: 初始化的协方差矩阵，根据类型有不同的形状
+        """
+        if self.covariance_type == 'full':
+            # 完整协方差：每个成分独立的 dxd 协方差矩阵
+            return np.array([np.eye(n_features) for _ in range(self.n_components)])
+        elif self.covariance_type == 'tied':
+            # 共享协方差：所有成分共享一个 dxd 协方差矩阵
+            return np.eye(n_features)
+        elif self.covariance_type == 'diagonal':
+            # 对角协方差：每个成分独立的 d 维方差向量
+            return np.ones((self.n_components, n_features))
+        elif self.covariance_type == 'spherical':
+            # 球面协方差：每个成分只有一个标量方差
+            return np.ones(self.n_components)
+        else:
+            raise ValueError(f"无效的协方差类型: {self.covariance_type}")
 
     def fit(self, X):
         """使用EM算法训练模型
@@ -173,8 +210,8 @@ class GaussianMixtureModel:
             indices = self.rng.choice(n_samples, self.n_components, replace=False)
             self.mu = X[indices].copy()
         
-        # 初始化协方差矩阵为单位矩阵
-        self.sigma = np.array([np.eye(n_features) for _ in range(self.n_components)])
+        # 根据协方差类型初始化协方差矩阵
+        self.sigma = self._init_covariance(n_features)
 
         log_likelihood = -np.inf
 
@@ -348,20 +385,73 @@ class GaussianMixtureModel:
         参数:
             X: 输入数据，形状为(n_samples, n_features)
             mu: 所有成分的均值，形状为(n_components, n_features)
-            sigma: 所有成分的协方差矩阵，形状为(n_components, n_features, n_features)
+            sigma: 所有成分的协方差矩阵（根据类型有不同形状）
             
         返回:
             log_prob: 每个样本在每个成分下的对数概率密度，形状为(n_samples, n_components)
         """
         n_samples, n_features = X.shape
-        n_components = mu.shape[0]
+        
+        if self.covariance_type == 'diagonal':
+            return self._log_gaussian_diagonal(X, mu, sigma)
+        elif self.covariance_type == 'spherical':
+            return self._log_gaussian_spherical(X, mu, sigma)
+        else:
+            # full 或 tied 协方差
+            n_components = mu.shape[0]
+            log_prob = np.zeros((n_samples, n_components))
+            
+            if self.covariance_type == 'full':
+                for k in range(n_components):
+                    log_prob[:, k] = self._log_gaussian(X, mu[k], sigma[k])
+            elif self.covariance_type == 'tied':
+                for k in range(n_components):
+                    log_prob[:, k] = self._log_gaussian(X, mu[k], sigma)
+            
+            return log_prob
 
-        log_prob = np.zeros((n_samples, n_components))
+    def _log_gaussian_diagonal(self, X, mu, sigma):
+        """向量化计算对角协方差高斯分布的对数概率密度
         
-        for k in range(n_components):
-            log_prob[:, k] = self._log_gaussian(X, mu[k], sigma[k])
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            mu: 所有成分的均值，形状为(n_components, n_features)
+            sigma: 对角协方差（方差向量），形状为(n_components, n_features)
+            
+        返回:
+            log_prob: 每个样本在每个成分下的对数概率密度，形状为(n_samples, n_components)
+        """
+        n_samples, n_features = X.shape
         
-        return log_prob
+        X_centered = X[:, np.newaxis, :] - mu[np.newaxis, :, :]  # (n, k, f)
+        log_det = np.sum(np.log(sigma), axis=1)                   # (k,)
+        inv_sigma = 1.0 / sigma                                   # (k, f)
+        
+        exponent = -0.5 * np.sum(X_centered ** 2 * inv_sigma[np.newaxis, :, :], axis=2)  # (n, k)
+        
+        return -0.5 * n_features * np.log(2 * np.pi) - 0.5 * log_det[np.newaxis, :] + exponent
+
+    def _log_gaussian_spherical(self, X, mu, sigma):
+        """向量化计算球面协方差高斯分布的对数概率密度
+        
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            mu: 所有成分的均值，形状为(n_components, n_features)
+            sigma: 球面方差（标量），形状为(n_components,)
+            
+        返回:
+            log_prob: 每个样本在每个成分下的对数概率密度，形状为(n_samples, n_components)
+        """
+        n_samples, n_features = X.shape
+        
+        X_centered = X[:, np.newaxis, :] - mu[np.newaxis, :, :]  # (n, k, f)
+        sq_dist = np.sum(X_centered ** 2, axis=2)                # (n, k)
+        log_det = n_features * np.log(sigma)                     # (k,)
+        inv_sigma = 1.0 / sigma                                  # (k,)
+        
+        exponent = -0.5 * sq_dist * inv_sigma[np.newaxis, :]     # (n, k)
+        
+        return -0.5 * n_features * np.log(2 * np.pi) - 0.5 * log_det[np.newaxis, :] + exponent
 
     def _log_gaussian_parallel(self, X, mu, sigma):
         """并行计算多个高斯成分的对数概率密度
@@ -369,28 +459,37 @@ class GaussianMixtureModel:
         参数:
             X: 输入数据，形状为(n_samples, n_features)
             mu: 所有成分的均值，形状为(n_components, n_features)
-            sigma: 所有成分的协方差矩阵，形状为(n_components, n_features, n_features)
+            sigma: 所有成分的协方差矩阵（根据类型有不同形状）
             
         返回:
             log_prob: 每个样本在每个成分下的对数概率密度，形状为(n_samples, n_components)
         """
         n_samples, n_features = X.shape
-        n_components = mu.shape[0]
-        n_jobs = self.n_jobs if self.n_jobs > 0 else min(n_components, 4)
         
-        log_prob = np.zeros((n_samples, n_components))
-        
-        def compute_component(k):
-            return k, self._log_gaussian(X, mu[k], sigma[k])
-        
-        with ThreadPoolExecutor(max_workers=n_jobs) as executor:
-            futures = [executor.submit(compute_component, k) for k in range(n_components)]
+        if self.covariance_type == 'diagonal':
+            return self._log_gaussian_diagonal(X, mu, sigma)
+        elif self.covariance_type == 'spherical':
+            return self._log_gaussian_spherical(X, mu, sigma)
+        else:
+            n_components = mu.shape[0]
+            n_jobs = self.n_jobs if self.n_jobs > 0 else min(n_components, 4)
             
-            for future in as_completed(futures):
-                k, result = future.result()
-                log_prob[:, k] = result
-        
-        return log_prob
+            log_prob = np.zeros((n_samples, n_components))
+            
+            def compute_component(k):
+                if self.covariance_type == 'full':
+                    return k, self._log_gaussian(X, mu[k], sigma[k])
+                else:  # tied
+                    return k, self._log_gaussian(X, mu[k], sigma)
+            
+            with ThreadPoolExecutor(max_workers=n_jobs) as executor:
+                futures = [executor.submit(compute_component, k) for k in range(n_components)]
+                
+                for future in as_completed(futures):
+                    k, result = future.result()
+                    log_prob[:, k] = result
+            
+            return log_prob
 
     def _compute_statistics_vectorized(self, X, gamma):
         """向量化计算 M 步的统计量
@@ -402,7 +501,7 @@ class GaussianMixtureModel:
         返回:
             Nk: 每个成分的有效样本数，形状为(n_components,)
             new_mu: 新均值，形状为(n_components, n_features)
-            new_sigma: 新协方差矩阵，形状为(n_components, n_features, n_features)
+            new_sigma: 新协方差矩阵（根据类型有不同形状）
         """
         n_samples, n_features = X.shape
         n_components = gamma.shape[1]
@@ -414,36 +513,153 @@ class GaussianMixtureModel:
         
         X_centered = X[:, np.newaxis, :] - new_mu[np.newaxis, :, :]
         gamma_X_centered = gamma[:, :, np.newaxis] * X_centered
-        new_sigma = np.einsum('nki,nkj->kij', gamma_X_centered, X_centered) / Nk[:, np.newaxis, np.newaxis]
         
-        regularization = np.eye(n_features) * 1e-6
-        new_sigma += regularization
+        if self.covariance_type == 'full':
+            new_sigma = np.einsum('nki,nkj->kij', gamma_X_centered, X_centered) / Nk[:, np.newaxis, np.newaxis]
+            regularization = np.eye(n_features) * 1e-6
+            new_sigma += regularization
+        elif self.covariance_type == 'tied':
+            new_sigma = np.einsum('nki,nkj->ij', gamma_X_centered, X_centered) / np.sum(gamma)
+            regularization = np.eye(n_features) * 1e-6
+            new_sigma += regularization
+        elif self.covariance_type == 'diagonal':
+            new_sigma = np.sum(gamma_X_centered ** 2, axis=0) / Nk[:, np.newaxis]
+            new_sigma = np.maximum(new_sigma, 1e-6)
+        elif self.covariance_type == 'spherical':
+            new_sigma = np.sum(gamma_X_centered ** 2) / np.sum(Nk * n_features)
+            new_sigma = np.maximum(new_sigma, 1e-6)
         
         return Nk, new_mu, new_sigma
         
     def plot_convergence(self, save_path = None, show = True):
         """可视化对数似然的收敛过程"""
-        # 检查是否有对数似然值记录
         if not self.log_likelihoods:
             raise ValueError("请先调用fit方法训练模型")
 
-        # 创建一个图形窗口，设置大小为10x6英寸
         plt.figure(figsize=(10, 6))
-        # 绘制对数似然值随迭代次数的变化曲线
-        # 使用蓝色实线绘制，范围从1到len(self.log_likelihoods)
         plt.plot(range(1, len(self.log_likelihoods) + 1), self.log_likelihoods, 'b-')
-        # 设置x轴的标签为“迭代次数”
         plt.xlabel('迭代次数')
-        # 设置y轴的标签为“对数似然值”
         plt.ylabel('对数似然值')
-        # 设置图表的标题为“EM算法收敛曲线”
         plt.title('EM算法收敛曲线')
-        # 启用网格线，增强可读性
         plt.grid(True, alpha=0.5) 
-        # 如提供保存路径，则写入文件
         if save_path is not None:
             plt.savefig(save_path, dpi=140, bbox_inches='tight')
-        # 是否显示窗口
+        if show:
+            plt.show()
+        else:
+            plt.close()
+
+    def predict_proba(self, X):
+        """预测样本属于各高斯成分的后验概率
+        
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            
+        返回:
+            probs: 后验概率矩阵，形状为(n_samples, n_components)
+        """
+        X = np.asarray(X)
+        
+        if self.n_jobs != 1:
+            log_prob = self._log_gaussian_parallel(X, self.mu, self.sigma)
+        else:
+            log_prob = self._log_gaussian_batch(X, self.mu, self.sigma)
+        
+        log_prob += np.log(self.pi)[np.newaxis, :]
+        log_prob_sum = logsumexp(log_prob, axis=1, keepdims=True)
+        
+        return np.exp(log_prob - log_prob_sum)
+
+    def score_samples(self, X):
+        """计算样本的对数概率密度（用于异常检测评分）
+        
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            
+        返回:
+            scores: 每个样本的对数概率密度，形状为(n_samples,)
+                    值越小表示样本越可能是异常值
+        """
+        X = np.asarray(X)
+        
+        if self.n_jobs != 1:
+            log_prob = self._log_gaussian_parallel(X, self.mu, self.sigma)
+        else:
+            log_prob = self._log_gaussian_batch(X, self.mu, self.sigma)
+        
+        log_prob += np.log(self.pi)[np.newaxis, :]
+        scores = logsumexp(log_prob, axis=1)
+        return scores.ravel()  # 确保返回一维数组
+
+    def detect_anomalies(self, X, contamination=0.05, threshold=None):
+        """基于密度估计检测异常样本
+        
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            contamination: 异常样本比例（默认0.05，即5%）
+            threshold: 异常检测阈值（可选，若不提供则根据contamination自动计算）
+            
+        返回:
+            is_anomaly: 异常标记数组，形状为(n_samples,)
+                        True表示异常样本，False表示正常样本
+            scores: 每个样本的异常分数（对数概率密度），形状为(n_samples,)
+        """
+        X = np.asarray(X)
+        n_samples = X.shape[0]
+        scores = self.score_samples(X).ravel()  # 确保是一维数组
+        
+        if threshold is None:
+            threshold = np.percentile(scores, contamination * 100)
+        
+        is_anomaly = (scores < threshold).ravel()  # 确保是一维数组
+        # 确保形状正确
+        if len(is_anomaly) != n_samples:
+            raise ValueError(f"异常检测结果形状错误: 预期 {n_samples}，实际 {len(is_anomaly)}")
+        
+        return is_anomaly, scores, threshold
+
+    def plot_anomaly_score(self, X, y_true=None, save_path=None, show=True):
+        """可视化异常检测结果
+        
+        参数:
+            X: 输入数据，形状为(n_samples, n_features)
+            y_true: 真实标签（可选，用于对比）
+            save_path: 保存路径（可选）
+            show: 是否显示（默认True）
+        """
+        X = np.asarray(X)
+        scores = self.score_samples(X).ravel()  # 确保是一维数组
+        
+        fig, axes = plt.subplots(1, 2, figsize=(16, 6))
+        
+        # 子图1：异常分数分布直方图
+        ax = axes[0]
+        ax.hist(scores.flatten(), bins=30, alpha=0.7, color='#3498DB', edgecolor='black')
+        ax.set_xlabel('对数概率密度（异常分数）')
+        ax.set_ylabel('频次')
+        ax.set_title('异常分数分布直方图\n（值越小越可能是异常）')
+        ax.grid(True, alpha=0.3)
+        
+        # 子图2：2D数据散点图（颜色表示异常分数）
+        ax = axes[1]
+        if X.shape[1] >= 2:
+            scatter = ax.scatter(X[:, 0], X[:, 1], c=scores, cmap='viridis', 
+                                alpha=0.7, edgecolors='black')
+            ax.set_xlabel('特征1')
+            ax.set_ylabel('特征2')
+            ax.set_title('数据散点图（颜色表示异常分数）')
+            plt.colorbar(scatter, ax=ax, label='对数概率密度')
+        else:
+            ax.scatter(range(len(scores)), scores, alpha=0.7, color='#E74C3C')
+            ax.set_xlabel('样本索引')
+            ax.set_ylabel('异常分数')
+            ax.set_title('异常分数分布图')
+        
+        plt.tight_layout()
+        
+        if save_path is not None:
+            plt.savefig(save_path, dpi=140, bbox_inches='tight')
+        
         if show:
             plt.show()
         else:
@@ -534,6 +750,8 @@ if __name__ == "__main__":
     parser.add_argument("--tol",          type=float, default=1e-6,    help="收敛阈值")
     parser.add_argument("--n-trials",     type=int,   default=50,      help="对比实验重复次数")
     parser.add_argument("--n-jobs",       type=int,   default=1,       help="并行计算线程数（-1表示使用所有CPU核心）")
+    parser.add_argument("--covariance-type", type=str, default="full", 
+                        help="协方差类型：full（完整协方差）、tied（共享协方差）、diagonal（对角协方差）、spherical（球面协方差）")
     parser.add_argument("--out-dir",      type=str,   default="outputs", help="输出目录")
     parser.add_argument("--no-show",      action="store_true",         help="不弹出图像窗口，仅保存文件")
     args = parser.parse_args()
@@ -771,6 +989,57 @@ if __name__ == "__main__":
             writer.writerow([r['n_components'], r['bic'], r['aic'], r['n_iters']])
 
     print(f"\n所有输出已保存至: {out_dir.resolve()}")
+
+    # ============================================================
+    # 异常检测功能演示
+    # ============================================================
+    print("\n--- 异常检测功能演示 ---")
+    
+    # 使用最佳模型进行异常检测
+    gmm_anomaly = GaussianMixtureModel(
+        n_components=best_gmm.n_components,
+        max_iter=100,
+        tol=1e-6,
+        random_state=42,
+        init='kmeans++',
+        n_jobs=args.n_jobs,
+        covariance_type=args.covariance_type
+    )
+    gmm_anomaly.fit(X)
+    
+    # 生成带异常值的测试数据
+    np.random.seed(42)
+    # 添加异常值（远离聚类中心的点）
+    n_anomalies = int(len(X) * 0.05)
+    anomalies = np.random.uniform(low=-15, high=15, size=(n_anomalies, X.shape[1]))
+    X_with_anomalies = np.vstack([X, anomalies])
+    y_anomaly_true = np.array([False] * len(X) + [True] * n_anomalies)
+    
+    # 检测异常
+    is_anomaly, scores, threshold = gmm_anomaly.detect_anomalies(X_with_anomalies, contamination=0.05)
+    
+    # 计算检测指标
+    tp = np.sum(is_anomaly & y_anomaly_true)
+    fn = np.sum(~is_anomaly & y_anomaly_true)
+    fp = np.sum(is_anomaly & ~y_anomaly_true)
+    tn = np.sum(~is_anomaly & ~y_anomaly_true)
+    
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0
+    
+    print(f"异常检测结果:")
+    print(f"  真实异常数: {n_anomalies}")
+    print(f"  检测异常数: {np.sum(is_anomaly)}")
+    print(f"  精确率: {precision:.4f}")
+    print(f"  召回率: {recall:.4f}")
+    print(f"  F1分数: {f1:.4f}")
+    
+    # 保存异常检测可视化图
+    anomaly_path = out_dir / "anomaly_detection.png"
+    gmm_anomaly.plot_anomaly_score(X_with_anomalies, y_true=y_anomaly_true, 
+                                   save_path=anomaly_path, show=not args.no_show)
+    print(f"[已保存] 异常检测图: {anomaly_path}")
 
 
 


### PR DESCRIPTION
1. 新增四种协方差类型：full/tied/diagonal/spherical，适配不同数据分布
2. 实现完整的异常检测模块，包含score_samples、detect_anomalies等方法
3. 优化logsumexp函数实现，修复维度处理逻辑
4. 添加命令行参数--covariance-type支持
5. 补充文档说明协方差类型与异常检测功能

<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述:     <!-- add this line for each issue your PR solves. -->
为 GMM（高斯混合模型）添加 异常检测扩展 功能，支持基于密度估计的离群点检测，同时完善 协方差类型扩展 ，支持 full 、 tied 、 diagonal 、 spherical 四种协方差类型。

## 修改的详细描述
异常检测扩展

新增 predict_proba(X)：预测样本属于各高斯成分的后验概率
新增 score_samples(X)：计算样本的对数概率密度（异常分数）
新增 detect_anomalies(X, contamination=0.05, threshold=None)：基于密度估计检测异常样本
新增 plot_anomaly_score(X, y_true=None, save_path=None, show=True)：可视化异常检测结果
在主函数中添加异常检测功能演示，自动生成检测报告和可视化图
协方差类型扩展

在 GaussianMixtureModel.__init__ 中添加 covariance_type 参数
新增 _init_covariance(n_features) 方法：根据类型初始化协方差矩阵
新增 _log_gaussian_diagonal(X, mu, sigma)：对角协方差对数概率计算
新增 _log_gaussian_spherical(X, mu, sigma)：球面协方差对数概率计算
修改 _compute_statistics_vectorized(X, gamma)：支持四种协方差类型的 M 步更新
修改 _log_gaussian_batch 和 _log_gaussian_parallel：适配不同协方差类型
修复 logsumexp 函数

修复 keepdims=False 时的形状处理问题，确保返回正确的一维数组
<!-- Describe what your PR is about. -->

## 经过了什么样的测试?
- 操作系统 ：Windows 10/11（64位）
- Python 版本 ：3.13.2
- 依赖库版本 ：
- NumPy：1.26.4
- Matplotlib：3.8.4

<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
--- 异常检测功能演示 ---
异常检测结果:
  真实异常数: 25
  检测异常数: 27
  精确率: 0.8519
  召回率: 0.9200
  F1分数: 0.8846
