### PR TITLE
在index中增加setup_tool汇报文档链接

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,8 @@ title: 主页
 
 [__人形机器人站立行走__](./mujoco_man/mujoco_manrun.md) -  基于 CPG + PD 的人形机器人稳定站立与行走仿真（MuJoCo）
 
+[__setup_tool模块汇报文档__](./setup_tool/report.md) - setup_tool 模块背景、改进内容、运行方式与效果总结
+
 ## 规划 <span id="planning"></span>
 
 [__导航__](#navigation)


### PR DESCRIPTION
修改概述：

无对应 issue，本次为 docs/index.md 增加 setup_tool 汇报文档入口链接。

## 修改的详细描述
1. 在 `docs/index.md` 中新增了指向 `docs/setup_tool/report.md` 的超链接。
2. 方便读者从索引页直接跳转到 setup_tool 模块汇报文档。
3. 提升了模块文档的可访问性。

## 经过了什么样的测试？
1. 操作系统：Windows 10
2. 使用 Git Bash 和 VS Code 完成修改
3. 检查了 Markdown 路径与链接格式
4. 确认文档可以正常保存、提交和推送

## 运行效果
本次修改为文档入口补充，未涉及程序逻辑变更。
