### PR TITLE
fix: car-navigation-bare-except

### DIFF
--- a/src/car_navigation_system/main.py
+++ b/src/car_navigation_system/main.py
@@ -305,7 +305,7 @@ class SimpleDrivingSystem:
                 array = np.frombuffer(image.raw_data, dtype=np.dtype("uint8"))
                 array = np.reshape(array, (image.height, image.width, 4))
                 self.camera_image = array[:, :, :3]  # RGB通道
-        except:
+        except Exception:
             pass
 
     def update_camera_view(self):
@@ -321,7 +321,7 @@ class SimpleDrivingSystem:
                     try:
                         camera.stop()
                         camera.destroy()
-                    except:
+                    except Exception:
                         pass
             self.cameras.clear()
 
@@ -329,7 +329,7 @@ class SimpleDrivingSystem:
             if self.vehicle:
                 try:
                     self.vehicle.destroy()
-                except:
+                except Exception:
                     pass
                 self.vehicle = None
             
@@ -440,7 +440,7 @@ class SimpleDrivingSystem:
                         try:
                             camera.stop()
                             camera.destroy()
-                        except:
+                        except Exception:
                             pass
                 self.cameras.clear()
                 
@@ -527,7 +527,7 @@ class SimpleDrivingSystem:
                         try:
                             camera.stop()
                             camera.destroy()
-                        except:
+                        except Exception:
                             pass
                 self.cameras.clear()
                 
@@ -845,7 +845,7 @@ class SimpleDrivingSystem:
                             npc.set_autopilot(True)
                             npc_vehicles.append(npc)
                             print(f"生成NPC车辆 {len(npc_vehicles)}")
-                except:
+                except Exception:
                     pass
 
             print(f"成功生成 {len(npc_vehicles)} 辆NPC车辆")
@@ -876,13 +876,13 @@ class SimpleDrivingSystem:
                 try:
                     camera.stop()
                     camera.destroy()
-                except:
+                except Exception:
                     pass
 
         if self.vehicle:
             try:
                 self.vehicle.destroy()
-            except:
+            except Exception:
                 pass
 
         # 等待销毁完成


### PR DESCRIPTION
## 修改概述
将 `src/car_navigation_system/main.py` 中所有裸 `except:` 替换为 `except Exception:`。

## 修改的详细描述
裸 `except:` 会捕获 `SystemExit` 和 `KeyboardInterrupt`。代码中共有 8 处裸 `except:`，分布在 `camera_callback`、`switch_map`、`switch_color`、`switch_vehicle`、`spawn_npc_vehicles` 和清理函数中。全部替换为 `except Exception:`。

## 经过了什么样的测试?
代码静态检查，确认所有 8 处均已正确替换。

## 运行效果
无运行时变化。