### PR TITLE
fix: replace deprecated np.int() with int() in active_lane_keeping/la…

### DIFF
--- a/src/active_lane_keeping/lane.py
+++ b/src/active_lane_keeping/lane.py
@@ -137,7 +137,7 @@ class Lane:
                 [2]: Width-index of the location of the right lane.
         """
         hist = np.sum(img[int(img.shape[0]/2):,:], axis=0)
-        midpoint = np.int(hist.shape[0]/2)
+        midpoint = int(hist.shape[0]/2)
         left_lane = np.argmax(hist[:midpoint])
         right_lane = np.argmax(hist[midpoint:]) + midpoint
 
@@ -174,7 +174,7 @@ class Lane:
         """
         # Number of pixels to identify line.
         MINIMAL_AREA = int((1/24) * self.img_width)
-        WINDOW_HEIGHT = np.int(img.shape[0]/number_windows)       
+        WINDOW_HEIGHT = int(img.shape[0]/number_windows)       
     
         # Retrive x and y coordinates of white pixels (non-zero).
         nonzero_y, nonzero_x = img.nonzero()
@@ -212,9 +212,9 @@ class Lane:
                 
             # Recenter next window on mean position.
             if len(non_zero_left_idxs) > MINIMAL_AREA:
-                max_left_idx = np.int(np.mean(nonzero_x[non_zero_left_idxs]))
+                max_left_idx = int(np.mean(nonzero_x[non_zero_left_idxs]))
             if len(non_zero_right_idxs) > MINIMAL_AREA:        
-                max_right_idx = np.int(np.mean(nonzero_x[non_zero_right_idxs]))
+                max_right_idx = int(np.mean(nonzero_x[non_zero_right_idxs]))
                         
         left_lane_idxs = np.concatenate(left_lane_idxs)
         right_lane_idxs = np.concatenate(right_lane_idxs)


### PR DESCRIPTION
## 修改概述
将 `src/active_lane_keeping/lane.py` 中已弃用的 `np.int()` 替换为内置 `int()`。

## 修改的详细描述
`np.int()` 在 NumPy 1.20 中标记为弃用，在 NumPy 1.24 中被移除。代码中有 4 处调用（第 140、177、215、217 行），全部替换为 Python 内置的 `int()` 函数，功能完全等价。

## 经过了什么样的测试?
代码静态检查，确认 4 处 `np.int(` 均已替换为 `int(`。

## 运行效果
无运行时变化，但修复了 NumPy 1.24+ 环境下的 `AttributeError`。