### PR TITLE
fix: correct typo suface_upper_threshold in active_lane_keeping/agent.py

### DIFF
--- a/src/active_lane_keeping/agent.py
+++ b/src/active_lane_keeping/agent.py
@@ -10,7 +10,7 @@ class Agent():
 
     def __init__(self, tau_p:float = 0, tau_d:float = 0, tau_i:float = 0,
         surface_lower_threshold:float = 20e6, throttle:float = 0.3,
-        suface_upper_threshold=30e6, controller:str = 'simple') -> None:
+        surface_upper_threshold=30e6, controller:str = 'simple') -> None:
         """Constructor
 
         Args:
@@ -25,7 +25,7 @@ class Agent():
                 helps to find suitable lanes. Defaults to 20e6.
             throttle (float, optional): Throttle to return at each time step.
                 Defaults to 0.3.
-            suface_upper_threshold (_type_, optional): Maximum amount of surface
+            surface_upper_threshold (float, optional): Maximum amount of surface
                 that has to be detected in order to calculate new output. This
                 helps to find suitable lanes. Defaults to 30e6.
             controller (str, optional): Identifies the controller to be used.
@@ -42,7 +42,7 @@ class Agent():
         self.tau_d = tau_d
         self.tau_i = tau_i
         self.surface_lower_threshold = surface_lower_threshold
-        self.surface_upper_threshold = suface_upper_threshold
+        self.surface_upper_threshold = surface_upper_threshold
         self.prev_error = None
         self.throttle = throttle
         self.func = None


### PR DESCRIPTION
## 修改概述
修正 `src/active_lane_keeping/agent.py` 中参数名拼写错误 `suface_upper_threshold` → `surface_upper_threshold`。

## 修改的详细描述
参数名 `suface` 少了一个字母 `r`，应为 `surface`。涉及 3 处修改：
1. 构造函数参数名（第 13 行）
2. 文档字符串中的参数说明（第 28 行），同时将 `_type_` 类型注解修正为 `float`
3. 赋值语句（第 45 行）

## 经过了什么样的测试?
代码静态检查，确认拼写错误已全部修正。

## 运行效果
修复后使用正确参数名 `surface_upper_threshold`，对外部调用无影响（原拼写错误可能导致参数传递失败）。