### PR TITLE
fix: replace unused time import and use ValueError in carla_autonomou…

### DIFF
--- a/src/carla_autonomous_car/main.py
+++ b/src/carla_autonomous_car/main.py
@@ -32,7 +32,7 @@ import inspect
 import argparse
 import os.path as osp
 from pathlib import Path
-import time
+from datetime import datetime
 import json
 import numpy as np
 


### PR DESCRIPTION
## 修改概述
修复 `src/carla_autonomous_car/main.py` 中未使用的导入和过于宽泛的异常类型。

## 修改的详细描述
1. 第 35 行：将未使用的 `import time` 替换为 `from datetime import datetime`，因为代码中实际使用的是 `datetime.now()`
2. 第 280、305 行：将 `raise Exception('Algorithm name is not defined!')` 替换为更具体的 `raise ValueError('Algorithm name is not defined!')`

## 经过了什么样的测试?
代码静态检查，确认导入和异常类型已修正。

## 运行效果
修复了可能的 `NameError`（`datetime` 未导入），异常类型更精确。