### PR TITLE
fix: remove redundant (object) from class definition in biomechanical…

### DIFF
--- a/src/biomechanical_platform/main.py
+++ b/src/biomechanical_platform/main.py
@@ -10,7 +10,7 @@ from std_msgs.msg import Float32MultiArray, Float32, Bool
 from uitb import Simulator
 
 
-class RCCarNode(object):
+class RCCarNode:
     def __init__(self, simulator_folder, rate_hz=30.0):
         rospy.loginfo("RCCarNode init, simulator_folder: %s", simulator_folder)
 


### PR DESCRIPTION
## 修改概述
移除 `src/biomechanical_platform/main.py` 中冗余的 `(object)` 继承。

## 修改的详细描述
Python 3 中所有类都隐式继承自 `object`，无需显式声明。将 `class RCCarNode(object):` 改为 `class RCCarNode:`，更符合现代 Python 风格。

## 经过了什么样的测试?
代码静态检查，确认类定义已简化。

## 运行效果
无运行时变化。