### PR TITLE
fix: use except Exception and RuntimeError in spawn_car.py

### DIFF
--- a/src/hutb_carla_selfdrivingcar/spawn_car.py
+++ b/src/hutb_carla_selfdrivingcar/spawn_car.py
@@ -8,6 +8,6 @@ def create_vehicle(world, carla_map):
         try:
             vehicle = world.spawn_actor(vehicle_bp, point)
             return vehicle
-        except:
+        except Exception:
             continue
-    raise Exception("车辆生成失败")
+    raise RuntimeError("车辆生成失败")


### PR DESCRIPTION
## 修改概述
修复 `src/hutb_carla_selfdrivingcar/spawn_car.py` 中的裸 `except:` 和过于宽泛的异常类型。

## 修改的详细描述
1. 第 11 行：将裸 `except:` 替换为 `except Exception:`，避免意外捕获 `SystemExit` 和 `KeyboardInterrupt`
2. 第 13 行：将 `raise Exception("车辆生成失败")` 替换为更具体的 `raise RuntimeError("车辆生成失败")`

## 经过了什么样的测试?
代码静态检查，确认异常处理已修正。

## 运行效果
异常处理更精确，程序可正常被中断。