### PR TITLE
fix: replace mutable default arguments with None in yolo.py

### DIFF
--- a/src/yolov4_vehicle_inspection/yolo.py
+++ b/src/yolov4_vehicle_inspection/yolo.py
@@ -134,7 +134,11 @@ class YOLO(object):
     # 核心方法，输入图像进行目标检测+简易追踪，返回绘制了检测框/轨迹的图像
     # cars：已追踪目标的坐标列表（每个元素为目标的历史中心坐标）
     # car_not_vis：每个追踪目标的连续不可见帧数
-    def detect_image(self, image, cars=[], car_not_vis=[]):
+    def detect_image(self, image, cars=None, car_not_vis=None):
+        if cars is None:
+            cars = []
+        if car_not_vis is None:
+            car_not_vis = []
         # ---------------------------------------------------------#
         #   在这里将图像转换成RGB图像，防止灰度图在预测时报错。
         # ---------------------------------------------------------#


### PR DESCRIPTION
## 修改概述
修复 `src/yolov4_vehicle_inspection/yolo.py` 中可变默认参数导致的状态共享 bug。

## 修改的详细描述
`detect_image` 方法使用 `cars=[]` 和 `car_not_vis=[]` 作为默认参数。Python 中可变默认参数在函数定义时只创建一次，后续调用共享同一个列表对象。如果列表被修改（如 append），状态会在调用间泄漏。修复方式：将默认值改为 `None`，在函数体内创建新列表。

## 经过了什么样的测试?
代码静态检查，确认默认参数已改为 None 并在函数体内初始化。

## 运行效果
修复了多次调用间状态泄漏的潜在 bug。