### PR TITLE
fix: rename shadowed builtin `id` to `run_id` in active_lane_keeping/…

### DIFF
--- a/src/active_lane_keeping/main.py
+++ b/src/active_lane_keeping/main.py
@@ -14,12 +14,12 @@ from agent import Agent
 from recorder import Recorder
 from world import World
 
-def log_parameters(id:str, logger:logging.Logger, parameters: Iterable[float],
+def log_parameters(run_id:str, logger:logging.Logger, parameters: Iterable[float],
     delta_parameters: Iterable[float], error:float, steps:int) -> None:
     """Log one set of Parameters
 
     Args:
-        id (str): An unique identifier used to identify the run.
+        run_id (str): An unique identifier used to identify the run.
         logger (logging.Logger): Logger that writes logs.
         parameters (Iterable[float]): Parameters of the controller.
         delta_parameters (Iterable[float]): Delta parameters for adaption of the
@@ -27,10 +27,10 @@ def log_parameters(id:str, logger:logging.Logger, parameters: Iterable[float],
         error (float): Summed error received by the environment.
         steps (int): Number of steps taken within the run.
     """
-    logger.info((f'id: {id} | parameters: {parameters} | delta_parameters: '
+    logger.info((f'id: {run_id} | parameters: {parameters} | delta_parameters: '
         f'{delta_parameters} | error: {error:.5f} | steps: {steps:5d}'))
 
-def run(id:str, path:str, world:World, agent:Agent, steps:int = 100,
+def run(run_id:str, path:str, world:World, agent:Agent, steps:int = 100,
     save:bool=False) -> tuple[float, int]:
     """One Epsisode inside the World
 
@@ -38,7 +38,7 @@ def run(id:str, path:str, world:World, agent:Agent, steps:int = 100,
     collision was detected.
 
     Args:
-        id (str): An unique identifier used to identify the run.
+        run_id (str): An unique identifier used to identify the run.
         path (str): Path where all files for a run will be stored.
         world (World): Environment for the simulation.
         agent (Agent): Agent to decide on actions.
@@ -56,7 +56,7 @@ def run(id:str, path:str, world:World, agent:Agent, steps:int = 100,
 
     if save:
         recorder = Recorder(folder=path)
-        recorder.init_new_video(id=id)
+        recorder.init_new_video(id=run_id)
 
     for i in range(steps):
         steer, throttle = agent.get_actions(detection_surface_area, error)
@@ -72,7 +72,7 @@ def run(id:str, path:str, world:World, agent:Agent, steps:int = 100,
             agent.show_error()
             break
 
-    agent.save_error_fig(path, id)
+    agent.save_error_fig(path, run_id)
     if save:
         recorder.close_recording()
 
@@ -96,14 +96,14 @@ def check_supported_controller(name:str) -> str:
         return 'pid'
     return name
 
-def get_logger(id:str, path:str, debug:bool=False) -> logging.Logger:
+def get_logger(run_id:str, path:str, debug:bool=False) -> logging.Logger:
     """Retrieve logger
 
     The returned logger 'pacman_rl' writes to a file inside the 'logs' folder
     and streams the logs to the console.
 
     Args:
-        id (str): An unique identifier used to identify the log file.
+        run_id (str): An unique identifier used to identify the log file.
         path (str): Path where all files for a run will be stored.
         debug (bool, optional): Whether to use the debug mode for logging. If
             False, only infos will be logged. Defaults to False.
@@ -119,7 +119,7 @@ def get_logger(id:str, path:str, debug:bool=False) -> logging.Logger:
     formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
     logger = logging.getLogger('active_lane_keeping_assistant')
     logger.setLevel(level=level)
-    fh = logging.FileHandler(join(path, f'alka_{id}.log'), mode='a')
+    fh = logging.FileHandler(join(path, f'alka_{run_id}.log'), mode='a')
     sh = logging.StreamHandler()
     sh.setFormatter(formatter)
     fh.setFormatter(formatter)
@@ -128,7 +128,7 @@ def get_logger(id:str, path:str, debug:bool=False) -> logging.Logger:
 
     return logger
 
-def twiddle(id:str, path:str, tolerance:float=0.2, controller:str='pid',
+def twiddle(run_id:str, path:str, tolerance:float=0.2, controller:str='pid',
     steps:int=100, debug:bool=False) -> None:
     """Twiddle-Algorithm
 
@@ -136,7 +136,7 @@ def twiddle(id:str, path:str, tolerance:float=0.2, controller:str='pid',
     PID-controller.
 
     Args:
-        id (str): An unique identifier used to identify the run.
+        run_id (str): An unique identifier used to identify the run.
         path (str): Path where all files for a run will be stored.
         tolerance (float, optional): Value that must be undershot for the
             algorithm to be terminated. Defaults to 0.2.
@@ -147,32 +147,32 @@ def twiddle(id:str, path:str, tolerance:float=0.2, controller:str='pid',
         debug (bool, optional): Whether to use the debug mode for logging.
             Defaults to False.
     """
-    logger = get_logger(id=id, path=path, debug=debug)
+    logger = get_logger(run_id=run_id, path=path, debug=debug)
     controller = check_supported_controller(name=controller)
 
-    logger.info(f'twiddle: {id}')
+    logger.info(f'twiddle: {run_id}')
     logger.info((f'tolerance: {tolerance} | controller: {controller} | steps: '
         f'{steps}'))
 
     parameters = np.zeros(3)
     delta_parameters = np.ones(3)
-    
+
     world = World()
     agent = Agent(controller=controller, tau_p=parameters[0],
         tau_i=parameters[1], tau_d=parameters[2])
 
-    best_err, steps_taken = run(id, path, world, agent, steps, save=False)
+    best_err, steps_taken = run(run_id, path, world, agent, steps, save=False)
     best_parameters = parameters
-    best_id = id
+    best_id = run_id
 
-    log_parameters(id, logger, parameters, delta_parameters, best_err,
+    log_parameters(run_id, logger, parameters, delta_parameters, best_err,
         steps_taken)
 
     for t in count():
         if (sum(delta_parameters) < tolerance):
             break
         for i in range(len(parameters)):
-            new_id = f'{id}_{t}_{i}_a'
+            new_id = f'{run_id}_{t}_{i}_a'
             world.id = new_id
             parameters[i] += delta_parameters[i]
 
@@ -190,7 +190,7 @@ def twiddle(id:str, path:str, tolerance:float=0.2, controller:str='pid',
                 delta_parameters[i] *= 1.1
             else:
                 logger.debug(f'Trying opposite direction for parameter {i}.')
-                new_id = f'{id}_{t}_{i}_a'
+                new_id = f'{run_id}_{t}_{i}_a'
                 world.id = new_id
                 parameters[i] -= 2*delta_parameters[i]
 
@@ -213,18 +213,18 @@ def twiddle(id:str, path:str, tolerance:float=0.2, controller:str='pid',
                         f'Decreasing step size.'))
                     parameters[i] += delta_parameters[i]
                     delta_parameters[i] *= 0.9
-    
+
     logger.info((f'best run - id: {best_id} | parameters: {best_parameters} | '
         f'error: {best_err:.5f}'))
 
-def no_adapt(id:str, path:str, steps:int=100, controller:str='simple') -> None:
+def no_adapt(run_id:str, path:str, steps:int=100, controller:str='simple') -> None:
     """Run without adaption
 
     Run the environment without the adaption of the parameters from the
     controller.
 
     Args:
-        id (str): Unique identifier for the run.
+        run_id (str): Unique identifier for the run.
         path (str): Path where all files for a run will be stored.
         steps (int, optional): Number of steps to take within the environment.
             Defaults to 100.
@@ -235,13 +235,13 @@ def no_adapt(id:str, path:str, steps:int=100, controller:str='simple') -> None:
     try:
         world = World()
         agent = Agent(controller=controller)
-        run(id=id, path=path, world=world, agent=agent, steps=steps, save=True)
+        run(run_id=run_id, path=path, world=world, agent=agent, steps=steps, save=True)
     finally:
         if world is not None:
             world.close()
 
 
-def make_path(folder:str, id:str) -> str:
+def make_path(folder:str, run_id:str) -> str:
     """Create folder
 
     Checks if a folder for the id already exists and creates the folder if
@@ -250,13 +250,13 @@ def make_path(folder:str, id:str) -> str:
     Args:
         folder (str): Name of the folder where the folder for the run will be
             located.
-        id (str): Unique identifier for the run. This will be used to identify
+        run_id (str): Unique identifier for the run. This will be used to identify
             the specific folder for this run.
 
     Returns:
         str: Path including the id of the run.
     """
-    path = join(os.getcwd(), folder, id)
+    path = join(os.getcwd(), folder, run_id)
 
     if not os.path.exists(path):
         os.makedirs(path)
@@ -287,11 +287,11 @@ if __name__ == '__main__':
         'if adapt is set to true.'), dest='debug')
     args = parser.parse_args()
 
-    path = make_path(folder='assets', id=args.id)
+    path = make_path(folder='assets', run_id=args.id)
 
     if args.adapt:
-        twiddle(id=args.id, path=path, tolerance=args.tolerance,
-            controller=args.controller, steps=args.steps, debug=args.debug)        
+        twiddle(run_id=args.id, path=path, tolerance=args.tolerance,
+            controller=args.controller, steps=args.steps, debug=args.debug)
     else:
-        no_adapt(id=args.id, path=path, steps=args.steps,
+        no_adapt(run_id=args.id, path=path, steps=args.steps,
             controller=args.controller)


### PR DESCRIPTION
## 修改概述
修复 `src/active_lane_keeping/main.py` 中参数名 `id` 遮蔽 Python 内置函数的问题。

## 修改的详细描述
6 个函数使用 `id` 作为参数名，遮蔽了 Python 内置的 `id()` 函数。在这些函数体内调用 `id(obj)` 会返回字符串参数而非对象内存地址。将所有函数的 `id` 参数重命名为 `run_id`：`log_parameters`、`run`、`get_logger`、`twiddle`、`no_adapt`、`make_path`。

## 经过了什么样的测试?
代码静态检查，确认所有 6 个函数的参数名和文档字符串已更新，调用处已同步修改。

## 运行效果
消除了内置函数遮蔽风险，代码更清晰。