### PR TITLE
fix: use `is None` instead of `== None` in roc_functions.py

### DIFF
--- a/src/carla_CAM/visualizer/roc_functions.py
+++ b/src/carla_CAM/visualizer/roc_functions.py
@@ -86,7 +86,7 @@ def preprocess_image(pil_im, sendToGPU=True, resize_im=True):
 
 
 def get_image_path(path, filename):
-    if filename == None:
+    if filename is None:
         onlyimages = [path + f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f)) & f.endswith(('.jpg','.png'))]
         return onlyimages
     else:


### PR DESCRIPTION
## 修改概述
修复 `src/carla_CAM/visualizer/roc_functions.py` 中 `== None` 比较方式。

## 修改的详细描述
将 `if filename == None:` 改为 `if filename is None:`。PEP 8 明确建议使用 `is None` 进行单例比较。`== None` 会调用对象的 `__eq__` 方法，对自定义相等行为的对象可能返回意外结果。

## 经过了什么样的测试?
代码静态检查，确认比较方式已修正。

## 运行效果
符合 PEP 8 规范，避免自定义 `__eq__` 导致的意外行为。