### PR TITLE
fix: use generator expression instead of list comprehension in join()

### DIFF
--- a/src/torcs_end2end/snakeoil3_gym.py
+++ b/src/torcs_end2end/snakeoil3_gym.py
@@ -473,7 +473,7 @@ class DriverAction():
             if not type(v) is list:
                 out += '%.3f' % v
             else:
-                out += ' '.join([str(x) for x in v])
+                out += ' '.join(str(x) for x in v)
             out += ')'
         return out
 


### PR DESCRIPTION

## 修改概述
优化 `src/torcs_end2end/snakeoil3_gym.py` 中 `str.join()` 的内存效率。

## 修改的详细描述
将 `' '.join([str(x) for x in v])` 改为 `' '.join(str(x) for x in v)`。`str.join()` 接受任意可迭代对象，使用生成器表达式比列表推导式更节省内存，因为不需要创建中间列表。

## 经过了什么样的测试?
代码静态检查，确认列表推导式已替换为生成器表达式。

## 运行效果
减少了内存分配，对大型列表效果更明显。