### PR TITLE
fix: 修正 pipe 方法中左右车道线索引传递顺序错误

### DIFF
--- a/src/active_lane_keeping/lane.py
+++ b/src/active_lane_keeping/lane.py
@@ -502,7 +502,7 @@ class Lane:
         img, inverse_perspective_transform = self.extract_roi(img)
         _, max_left_idx, max_right_idx = self.get_hist(img)
         left_line, right_line = self.get_line_fits(img.copy(),
-            max_right_idx, max_left_idx)
+            max_left_idx, max_right_idx)
         left_fit_x, right_fit_x, y = self.get_search_window(img.copy(),
             left_line, right_line)
         img, detection_surface_area = self.show_lane(original_image,


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

## 修改概述
修复 `Lane.pipe()` 方法中调用 `get_line_fits` 时左右车道线索引传递顺序错误的问题。

## 修改的详细描述
1. 原代码中，`get_line_fits(img.copy(), max_right_idx, max_left_idx)` 错误地将右车道索引作为左车道参数、左车道索引作为右车道参数传入。
2. 现已更正为 `get_line_fits(img.copy(), max_left_idx, max_right_idx)`，使参数顺序与函数定义一致（先左后右）。

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果

<img width="740" height="111" alt="屏幕截图 2026-05-14 213638" src="https://github.com/user-attachments/assets/05d3182b-f058-4e91-b184-8020f7830546" />
