### PR TITLE
fix: 修复 example.py 中 TOG 与 PCB 攻击演示的函数指针绑反问题

### DIFF
--- a/src/z_2d_tracking/what/cli/example.py
+++ b/src/z_2d_tracking/what/cli/example.py
@@ -20,6 +20,6 @@ what_example_list = [
     ('     YoloX Demo    ', ' Model Inference ', 'YoloX Object Detection.', yolox_inference_demo),
     ('  FasterRCNN Demo  ', ' Model Inference ', 'FRCNN Object Detection.', frcnn_inference_demo),
     ('MobileNet SSD Demo', ' Model Inference ', 'MobileNet SSD Object Detection.', mobilenet_ssd_inference_demo),
-    (' TOG Attack Demo ', 'Adversarial Attack', 'Real-time TOG Attack against Yolov3 Tiny.', yolov3_pcb_attack_demo),
-    (' PCB Attack Demo ', 'Adversarial Attack', 'Real-time PCB Attack against Yolov3 Tiny.', yolov3_tog_attack_demo),
+    (' TOG Attack Demo ', 'Adversarial Attack', 'Real-time TOG Attack against Yolov3 Tiny.', yolov3_tog_attack_demo),
+    (' PCB Attack Demo ', 'Adversarial Attack', 'Real-time PCB Attack against Yolov3 Tiny.', yolov3_pcb_attack_demo),
 ]


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

## 修改概述
修复 `example.py` 中 `what_example_list` 里 TOG 攻击演示和 PCB 攻击演示的函数指针绑定错误。

## 修改的详细描述
原代码中：
- “TOG Attack Demo” 错误地绑定了 `yolov3_pcb_attack_demo`（实际应运行 PCB 攻击）
- “PCB Attack Demo” 错误地绑定了 `yolov3_tog_attack_demo`（实际应运行 TOG 攻击）

这导致用户在命令行选择 TOG 攻击时，程序实际执行的是 PCB 攻击，反之亦然。现已将两个函数指针调换，使其与描述一致。

## 经过了什么样的测试?
1. 操作系统
2. Python版本等
<!-- 请描述所做修改的测试，便于合并 -->

## 运行效果
动图、视频、截图等
