### PR TITLE
fix: add content to empty loco_MuJoCo README

### DIFF
--- a/src/loco_MuJoCo/README.md
+++ b/src/loco_MuJoCo/README.md
@@ -1,0 +1,19 @@
+# MuJoCo 运动控制仿真
+
+基于 MuJoCo 物理引擎的运动控制仿真项目，实现人形机器人的步态生成与运动控制。
+
+## 环境要求
+
+- Python 3.8+
+- MuJoCo 2.3.0+
+- NumPy
+
+## 快速开始
+
+```bash
+python main.py
+```
+
+## 参考资源
+
+- [MuJoCo 官方文档](https://mujoco.readthedocs.io/)


### PR DESCRIPTION
Add proper README content to loco_MuJoCo/README.md which was previously an empty file. Includes basic project description, environment requirements, quick start, and reference resources.