### PR TITLE
Speed cont

### DIFF
--- a/src/carla_black_tesla/main_horn_control.py
+++ b/src/carla_black_tesla/main_horn_control.py
@@ -1,0 +1,77 @@
+import carla
+import sys
+import time
+
+def main():
+    print("=" * 60)
+    print("CARLA - Black Tesla Horn Control")
+    print("=" * 60)
+
+    try:
+        client = carla.Client("localhost", 2000)
+        client.set_timeout(10.0)
+        print("[INFO] Connected to CARLA server")
+
+        world = client.get_world()
+        blueprint_library = world.get_blueprint_library()
+
+        tesla_bp = blueprint_library.find("vehicle.tesla.model3")
+        tesla_bp.set_attribute("color", "0, 0, 0")
+
+        spawn_points = world.get_map().get_spawn_points()
+
+        vehicle = None
+        for i, spawn_point in enumerate(spawn_points[:5]):
+            try:
+                vehicle = world.spawn_actor(tesla_bp, spawn_point)
+                print(f"[SUCCESS] Black Tesla spawned at point {i}!")
+                break
+            except RuntimeError as e:
+                if "collision" in str(e).lower():
+                    continue
+                else:
+                    raise
+
+        if vehicle is None:
+            print("[ERROR] Failed to spawn vehicle")
+            return
+
+        vehicle.set_autopilot(True)
+        print("[INFO] Autopilot enabled")
+        print("[INFO] Horn control enabled")
+
+        print("\n[INFO] Press Ctrl+C to stop")
+        print("[INFO] Horn will beep automatically...")
+        print("-" * 60)
+
+        try:
+            beep_count = 0
+            while True:
+                beep_count += 1
+                control = vehicle.get_control()
+                control.horn = True
+                vehicle.apply_control(control)
+                print(f"\r[INFO] Horn beep #{beep_count}", end="")
+                time.sleep(0.5)
+
+                control.horn = False
+                vehicle.apply_control(control)
+                time.sleep(2.5)
+
+        except KeyboardInterrupt:
+            print("\n[INFO] User interrupted")
+        finally:
+            if vehicle and vehicle.is_alive:
+                vehicle.destroy()
+                print("[INFO] Vehicle destroyed")
+
+    except RuntimeError as e:
+        print(f"[ERROR] {e}")
+        print("[INFO] Make sure CarlaUE4.exe is running")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[ERROR] Unexpected error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/carla_speed_recorder/main.py
+++ b/src/carla_speed_recorder/main.py
@@ -1,0 +1,91 @@
+import carla
+import sys
+import time
+import csv
+from datetime import datetime
+
+def main():
+    print("=" * 60)
+    print("CARLA - Speed Recorder")
+    print("=" * 60)
+
+    try:
+        client = carla.Client("localhost", 2000)
+        client.set_timeout(10.0)
+        print("[INFO] Connected to CARLA server")
+
+        world = client.get_world()
+        blueprint_library = world.get_blueprint_library()
+
+        tesla_bp = blueprint_library.find("vehicle.tesla.model3")
+        tesla_bp.set_attribute("color", "0, 0, 0")
+
+        spawn_points = world.get_map().get_spawn_points()
+
+        vehicle = None
+        for i, spawn_point in enumerate(spawn_points[:5]):
+            try:
+                vehicle = world.spawn_actor(tesla_bp, spawn_point)
+                print(f"[SUCCESS] Black Tesla spawned at point {i}!")
+                break
+            except RuntimeError as e:
+                if "collision" in str(e).lower():
+                    continue
+                else:
+                    raise
+
+        if vehicle is None:
+            print("[ERROR] Failed to spawn vehicle")
+            return
+
+        vehicle.set_autopilot(True)
+        print("[INFO] Autopilot enabled")
+        print("[INFO] Speed recording started")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"speed_log_{timestamp}.csv"
+
+        print(f"\n[INFO] Saving to: {filename}")
+        print("[INFO] Press Ctrl+C to stop")
+        print("-" * 60)
+
+        with open(filename, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(['Time', 'Speed (km/h)', 'X', 'Y', 'Z'])
+
+            count = 0
+            start_time = time.time()
+
+            try:
+                while True:
+                    elapsed = time.time() - start_time
+                    location = vehicle.get_location()
+                    velocity = vehicle.get_velocity()
+                    speed = ((velocity.x**2 + velocity.y**2 + velocity.z**2) ** 0.5)
+                    speed_kmh = speed * 3.6
+
+                    writer.writerow([f"{elapsed:.1f}", f"{speed_kmh:.1f}", f"{location.x:.2f}", f"{location.y:.2f}", f"{location.z:.2f}"])
+
+                    count += 1
+                    print(f"\r[INFO] Recording #{count} | Time: {elapsed:.1f}s | Speed: {speed_kmh:.1f} km/h", end="")
+                    
+                    time.sleep(0.5)
+
+            except KeyboardInterrupt:
+                print("\n[INFO] User interrupted")
+            finally:
+                if vehicle and vehicle.is_alive:
+                    vehicle.destroy()
+                    print("[INFO] Vehicle destroyed")
+                print(f"[INFO] Saved {count} records to {filename}")
+
+    except RuntimeError as e:
+        print(f"[ERROR] {e}")
+        print("[INFO] Make sure CarlaUE4.exe is running")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[ERROR] Unexpected error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 修复 CarRacing DQN/DoubleDQN 训练中终止语义（terminated/truncated）处理不一致导致的跨 episode bootstrap 问题，并补充可控开关与训练脚本参数化支持。

## 修改的详细描述
1. 在 `src/carla_speed_recorder/` 目录下新增 `main.py` 文件
2. 实现车辆速度和位置实时记录功能，每0.5秒记录一次
3. 自动生成带时间戳的 CSV 文件（格式：时间、速度、X/Y/Z坐标）
4. 车辆采用自动驾驶模式，可用于数据采集和性能分析

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：3.10
3. 测试环境：CARLA Simulator 0.9.15+
4. 运行命令：`python src/carla_speed_recorder/main.py`
5. 测试结果：车辆成功生成并自动驾驶，数据成功写入 CSV 文件

## 运行效果
该改动主要提升训练目标语义正确性与对比可复现性。建议在 GPU 环境固定 `--max-timesteps` 做长跑对比，并附上 reward/loss 曲线图（以及终端输出的 Mean(10)/SPS/UPS 片段截图）。

示例命令（GPU 机器）：
```bash
export MPLCONFIGDIR=/tmp/matplotlib

# truncated 视为 terminal（严格终止，不跨 episode bootstrap）
python /home/zhibing/nn/nn/src/car_racing/car_racing_ros/dqn_model/training_dqn.py \
  --episodes 200 --max-timesteps 200000 --batch-size 64 \
  --report none --log-every 1 --log-filename DQN_trunc_terminal.csv \
  --skip-eval --seed 123 \
  --dueling 1 --normalize-obs 1 --amp 1 --double-q 1 \
  --treat-truncated-as-terminal 1

# truncated 不视为 terminal（允许 bootstrap）
python /home/zhibing/nn/nn/src/car_racing/car_racing_ros/dqn_model/training_dqn.py \
  --episodes 200 --max-timesteps 200000 --batch-size 64 \
  --report none --log-every 1 --log-filename DQN_trunc_bootstrap.csv \
  --skip-eval --seed 123 \
  --dueling 1 --normalize-obs 1 --amp 1 --double-q 1 \
  --treat-truncated-as-terminal 0
```

曲线对比（生成图片后附在 PR）：
```bash
python /home/zhibing/nn/nn/src/car_racing/car_racing_ros/plot_comparison.py \
  --logs /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/logs/DQN_trunc_terminal.csv /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/logs/DQN_trunc_bootstrap.csv \
  --labels trunc_terminal trunc_bootstrap \
  --metric reward --smooth 20 \
  --out /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/dqn_reward_trunc_cmp.png \
  --title "DQN Reward (smooth=20)"
<img width="1557" height="1018" alt="image" src="https://github.com/user-attachments/assets/afaafce9-338d-45db-99e2-a148a9f10a7e" />

python /home/zhibing/nn/nn/src/car_racing/car_racing_ros/plot_comparison.py \
  --logs /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/logs/DQN_trunc_terminal.csv /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/logs/DQN_trunc_bootstrap.csv \
  --labels trunc_terminal trunc_bootstrap \
  --metric loss --smooth 20 \
  --out /home/zhibing/nn/nn/src/car_racing/car_racing_ros/training/dqn_loss_trunc_cmp.png \
  --title "DQN Loss (smooth=20)"
```

生成文件（示例）：
- 日志：`src/car_racing/car_racing_ros/training/logs/DQN_trunc_terminal.csv`、`DQN_trunc_bootstrap.csv`
- 图片：`src/car_racing/car_racing_ros/training/dqn_reward_trunc_cmp.png`、`dqn_loss_trunc_cmp.png`
