### PR TITLE
feat: 增强可视化工具，添加实时训练曲线和策略热力图

### DIFF
--- a/src/rl_workspace/agent/demo_visualization.py
+++ b/src/rl_workspace/agent/demo_visualization.py
@@ -1,0 +1,27 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from src.rl.visualizer import LivePlot, PolicyHeatmap
+
+# 测试实时曲线
+print("测试 LivePlot...")
+live = LivePlot(xlabel='Episode', ylabel='Reward', title='Demo Training Curve')
+for episode in range(100):
+    # 模拟奖励（噪声 + 上升趋势）
+    reward = 50 + episode * 0.5 + np.random.randn() * 5
+    live.update('reward', episode, reward)
+live.save("demo_live_plot.png")
+print("实时曲线已保存为 demo_live_plot.png")
+
+# 测试策略热力图
+print("测试 PolicyHeatmap...")
+heatmap = PolicyHeatmap(num_actions=4, env_name='DemoEnv')
+for step in range(0, 101, 10):
+    # 模拟策略概率（逐渐趋于某个动作）
+    probs = np.exp([step/30, 0, 0, 0])
+    probs = probs / probs.sum()
+    heatmap.update(probs, step)
+heatmap.save("demo_heatmap.png")
+print("热力图已保存为 demo_heatmap.png")
+
+print("演示完成！请关闭图形窗口。")
+plt.show(block=True)

--- a/src/rl_workspace/agent/src/examples/trainer.py
+++ b/src/rl_workspace/agent/src/examples/trainer.py
@@ -2,14 +2,18 @@
 强化学习训练工具模块
 
 提供统一的训练框架、日志记录和性能评估功能
+扩展：可视化回调管理、实时训练曲线集成
 """
 
 import json
 import os
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Callable, Any
 
 import numpy as np
+
+# 从 visualizer 导入新类
+from ..rl.visualizer import LivePlot, PolicyHeatmap, ValueSurface
 
 
 class TrainingLogger:
@@ -164,6 +168,166 @@ class HyperparameterTuner:
         
         return self.best_params
 
+
+# ========== 新增：可视化集成辅助类 ==========
+
+class VisualizationManager:
+    """
+    可视化管理器，用于在训练过程中管理 LivePlot、PolicyHeatmap 等
+    用法：
+        viz = VisualizationManager(env_name="CartPole", num_actions=2)
+        viz.setup_live_plot(xlabel='Episode', ylabel='Reward')
+        viz.setup_heatmap(num_actions=2)
+        for episode in range(N):
+            viz.update_live_plot('reward', episode, episode_reward)
+            probs = agent.get_action_probs(state)  # 需要算法提供
+            viz.update_heatmap(probs, episode)
+    """
+
+    def __init__(self, env_name: str = "RLEnv", log_dir: str = "visualizations"):
+        self.env_name = env_name
+        self.log_dir = log_dir
+        os.makedirs(log_dir, exist_ok=True)
+        self.live_plot: Optional[LivePlot] = None
+        self.heatmap: Optional[PolicyHeatmap] = None
+        self.value_surface: Optional[ValueSurface] = None
+
+    def setup_live_plot(self, xlabel: str = 'Episode', ylabel: str = 'Reward', title: str = 'Training Curve'):
+        """初始化实时曲线"""
+        self.live_plot = LivePlot(xlabel=xlabel, ylabel=ylabel, title=title)
+
+    def setup_heatmap(self, num_actions: int):
+        """初始化策略热力图"""
+        self.heatmap = PolicyHeatmap(num_actions=num_actions, env_name=self.env_name)
+
+    def setup_value_surface(self, bounds=((-3,3),(-3,3)), resolution=30):
+        """初始化价值曲面图"""
+        self.value_surface = ValueSurface(bounds=bounds, resolution=resolution)
+
+    def update_live_plot(self, name: str, x: float, y: float):
+        if self.live_plot:
+            self.live_plot.update(name, x, y)
+
+    def update_heatmap(self, probs: np.ndarray, step: int):
+        if self.heatmap:
+            self.heatmap.update(probs, step)
+
+    def update_value_surface(self, value_func: Callable[[np.ndarray], float], step: int):
+        if self.value_surface:
+            self.value_surface.update(value_func, step)
+
+    def save_all(self, prefix: str = "final"):
+        """保存所有当前图表"""
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        if self.live_plot:
+            self.live_plot.save(os.path.join(self.log_dir, f"{prefix}_live_plot_{timestamp}.png"))
+        if self.heatmap:
+            self.heatmap.save(os.path.join(self.log_dir, f"{prefix}_heatmap_{timestamp}.png"))
+        if self.value_surface:
+            self.value_surface.save(os.path.join(self.log_dir, f"{prefix}_surface_{timestamp}.png"))
+
+    def close_all(self):
+        """关闭所有图形窗口"""
+        if self.live_plot:
+            self.live_plot.close()
+        if self.heatmap:
+            self.heatmap.close()
+        if self.value_surface:
+            self.value_surface.close()
+
+
+# ========== 示例训练函数（展示如何集成可视化） ==========
+
+def train_with_visualization(agent, env, n_episodes: int = 500, 
+                             visualize: bool = True, 
+                             plot_interval: int = 10,
+                             log_dir: str = "training_logs"):
+    """
+    示例训练函数，展示如何使用 VisualizationManager 集成实时曲线和热力图
+    
+    参数:
+        agent: 强化学习代理，需要实现 get_action, update 等方法，并且如果是离散策略需要提供 get_action_probs
+        env: gym 环境
+        n_episodes: 训练轮数
+        visualize: 是否启用可视化
+        plot_interval: 每隔多少 episode 更新一次热力图
+        log_dir: 日志保存目录
+    """
+    logger = TrainingLogger(log_dir=os.path.join(log_dir, "logs"))
+    
+    viz = None
+    if visualize:
+        # 检查环境动作空间是否为离散
+        if hasattr(env.action_space, 'n'):
+            num_actions = env.action_space.n
+            viz = VisualizationManager(env_name=env.spec.id if env.spec else "RLEnv", 
+                                       log_dir=os.path.join(log_dir, "figures"))
+            viz.setup_live_plot(xlabel='Episode', ylabel='Total Reward', title='Training Progress')
+            viz.setup_heatmap(num_actions=num_actions)
+        else:
+            print("警告：连续动作空间暂不支持热力图，将只显示实时曲线")
+            viz = VisualizationManager(env_name=env.spec.id if env.spec else "RLEnv",
+                                       log_dir=os.path.join(log_dir, "figures"))
+            viz.setup_live_plot(xlabel='Episode', ylabel='Total Reward', title='Training Progress')
+    
+    all_rewards = []
+    
+    for episode in range(1, n_episodes + 1):
+        state = env.reset()[0] if isinstance(env.reset(), tuple) else env.reset()
+        done = False
+        total_reward = 0
+        step = 0
+        
+        while not done:
+            action = agent.get_action(state)
+            next_state, reward, done, trunc, info = env.step(action)
+            total_reward += reward
+            
+            # 假设 agent 有 update 方法 (如 QLearner 的 get_next_action_with_Q_table_update)
+            if hasattr(agent, 'update'):
+                agent.update(state, action, reward, next_state, done)
+            elif hasattr(agent, 'get_next_action_with_Q_table_update'):
+                # 针对 QLearner/SARSALearner 的集成
+                agent.get_next_action_with_Q_table_update(next_state, reward)
+            
+            state = next_state
+            step += 1
+        
+        all_rewards.append(total_reward)
+        logger.log(episode, {"reward": total_reward, "avg_reward": np.mean(all_rewards[-50:])})
+        
+        # 更新实时曲线
+        if viz and viz.live_plot:
+            viz.update_live_plot('reward', episode, total_reward)
+            viz.update_live_plot('avg_reward', episode, np.mean(all_rewards[-50:]))
+        
+        # 定期更新策略热力图（如果代理有 get_action_probs 方法）
+        if visualize and viz and viz.heatmap and episode % plot_interval == 0:
+            if hasattr(agent, 'get_action_probs'):
+                # 注意：需要算法类实现 get_action_probs，以下为示例
+                probs = agent.get_action_probs(state)  # 期望返回形状 (num_actions,)
+                viz.update_heatmap(probs, episode)
+            else:
+                # 对于 Q-Learning 类，可以从 Q 表计算 softmax 概率
+                if hasattr(agent, 'Q') and agent.Q is not None:
+                    q_values = agent.Q[state] if isinstance(state, tuple) else agent.Q[state]
+                    probs = np.exp(q_values) / np.sum(np.exp(q_values))
+                    viz.update_heatmap(probs, episode)
+        
+        if episode % 100 == 0:
+            print(f"Episode {episode}, Total Reward: {total_reward:.2f}, Avg Reward: {np.mean(all_rewards[-50:]):.2f}")
+    
+    # 训练结束，保存所有可视化图表
+    if viz:
+        viz.save_all(prefix="final")
+        viz.close_all()
+    
+    logger.save()
+    logger.print_summary()
+    return all_rewards
+
+
+# ========== 原有的辅助函数 ==========
 
 def load_q_table(filepath: str) -> np.ndarray:
     """加载Q表"""

--- a/src/rl_workspace/agent/src/rl/experiment_manager.py
+++ b/src/rl_workspace/agent/src/rl/experiment_manager.py
@@ -2,6 +2,7 @@
 实验管理和超参数优化模块
 
 提供实验跟踪、结果保存和自动超参数搜索功能
+扩展：自动保存 matplotlib 图表到实验目录
 """
 
 import os
@@ -39,6 +40,7 @@ class ExperimentTracker:
     实验跟踪器
     
     记录每次实验的配置、指标和结果
+    扩展：自动保存图表到实验子目录
     """
     
     def __init__(self, experiment_dir: str = "experiments"):
@@ -56,6 +58,10 @@ class ExperimentTracker:
             'metrics': {},
             'checkpoints': []
         }
+        # 创建实验专属的 figures 子目录
+        exp_id = self._generate_exp_id(config)
+        self.current_experiment['figure_dir'] = os.path.join(self.experiment_dir, exp_id, 'figures')
+        os.makedirs(self.current_experiment['figure_dir'], exist_ok=True)
     
     def log_metric(self, name: str, value: float, step: Optional[int] = None):
         """记录指标"""
@@ -87,6 +93,20 @@ class ExperimentTracker:
             'timestamp': time.time() - self.current_experiment['start_time']
         }
         self.current_experiment['checkpoints'].append(checkpoint)
+    
+    def save_figure(self, fig, filename: str):
+        """
+        自动保存 matplotlib 图表到当前实验的 figures 目录
+        参数：
+            fig: matplotlib.figure.Figure 对象
+            filename: 文件名（如 'training_curve.png'）
+        """
+        if self.current_experiment is None:
+            raise RuntimeError("没有正在进行的实验，请先调用 start_experiment")
+        filepath = os.path.join(self.current_experiment['figure_dir'], filename)
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        fig.savefig(filepath, dpi=150)
+        print(f"图表已保存到: {filepath}")
     
     def end_experiment(self, success: bool = True, error_message: Optional[str] = None):
         """结束实验"""
@@ -175,6 +195,8 @@ class ExperimentTracker:
         
         return summary
 
+
+# ========== 以下 HyperparameterOptimizer 和 ExperimentSuite 保持不变 ==========
 
 class HyperparameterOptimizer:
     """

--- a/src/rl_workspace/agent/src/rl/visualizer.py
+++ b/src/rl_workspace/agent/src/rl/visualizer.py
@@ -2,14 +2,168 @@
 可视化工具模块
 
 提供训练曲线绘制、Q表可视化、策略可视化等功能
+扩展：实时训练曲线、策略热力图、价值函数曲面图
 """
 
 import os
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Callable
 
 import matplotlib.pyplot as plt
 import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # 用于3D曲面
 
+
+class LivePlot:
+    """
+    实时更新训练曲线，支持多条曲线
+    用法：
+        live = LivePlot(xlabel='Episode', ylabel='Reward')
+        live.add_curve('reward', color='red')
+        for episode in range(N):
+            live.update('reward', episode, episode_reward)
+    """
+
+    def __init__(self, xlabel: str = 'Episode', ylabel: str = 'Value', title: str = 'Live Plot', max_points: int = 500):
+        plt.ion()
+        self.fig, self.ax = plt.subplots(figsize=(10, 5))
+        self.ax.set_xlabel(xlabel, fontsize=12)
+        self.ax.set_ylabel(ylabel, fontsize=12)
+        self.ax.set_title(title, fontsize=14)
+        self.ax.grid(True, alpha=0.3)
+        self.lines: Dict[str, plt.Line2D] = {}
+        self.data: Dict[str, tuple] = {}  # (xs, ys)
+        self.max_points = max_points
+
+    def add_curve(self, name: str, color: Optional[str] = None):
+        """添加一条新的曲线"""
+        line, = self.ax.plot([], [], label=name, color=color, linewidth=2)
+        self.lines[name] = line
+        self.data[name] = ([], [])
+        self.ax.legend(loc='best')
+
+    def update(self, name: str, x: float, y: float):
+        """更新指定曲线的最新点"""
+        if name not in self.lines:
+            self.add_curve(name)
+        xs, ys = self.data[name]
+        xs.append(x)
+        ys.append(y)
+        if len(xs) > self.max_points:
+            xs.pop(0)
+            ys.pop(0)
+        self.lines[name].set_data(xs, ys)
+        # 自动调整坐标轴范围
+        self.ax.relim()
+        self.ax.autoscale_view()
+        plt.pause(0.001)  # 短暂暂停以刷新图形
+
+    def save(self, filepath: str, dpi: int = 150):
+        """保存当前图表（自动创建目录）"""
+        dirname = os.path.dirname(filepath)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        self.fig.savefig(filepath, dpi=dpi)
+        print(f"实时图表已保存到: {filepath}")
+
+    def close(self):
+        plt.close(self.fig)
+
+
+class PolicyHeatmap:
+    """
+    离散动作策略热力图，实时展示各动作的概率分布
+    需要算法提供 get_action_probs(state) 方法返回概率数组 (num_actions,)
+    """
+
+    def __init__(self, num_actions: int, env_name: str = "Unknown"):
+        self.num_actions = num_actions
+        self.fig, self.ax = plt.subplots(figsize=(8, 3))
+        self.im = None
+        self.env_name = env_name
+        self.step = 0
+
+    def update(self, probs: np.ndarray, step: int):
+        """
+        probs: shape (num_actions,)，概率值，应归一化
+        step: 当前训练步数/episode数
+        """
+        self.step = step
+        if self.im is None:
+            # 初始绘制
+            self.im = self.ax.imshow([probs], aspect='auto', cmap='viridis', vmin=0, vmax=1)
+            self.ax.set_ylabel('Policy', fontsize=12)
+            self.ax.set_xlabel('Action', fontsize=12)
+            self.ax.set_title(f'Policy Probabilities at Step {step} ({self.env_name})', fontsize=14)
+            self.ax.set_yticks([])
+            self.ax.set_xticks(range(self.num_actions))
+            plt.colorbar(self.im, ax=self.ax, label='Probability')
+        else:
+            self.im.set_array([probs])
+            self.ax.set_title(f'Policy Probabilities at Step {step} ({self.env_name})')
+        plt.pause(0.001)
+
+    def save(self, filepath: str):
+        """保存当前图表（自动创建目录）"""
+        dirname = os.path.dirname(filepath)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        self.fig.savefig(filepath, dpi=150)
+        print(f"策略热力图已保存到: {filepath}")
+
+    def close(self):
+        plt.close(self.fig)
+
+
+class ValueSurface:
+    """
+    3D价值函数曲面图，适用于2维连续状态空间（如位置+速度）
+    需要提供一个 value_function: np.ndarray -> float 的可调用对象
+    """
+
+    def __init__(self, bounds: tuple = ((-3, 3), (-3, 3)), resolution: int = 30):
+        """
+        bounds: ((x_min, x_max), (y_min, y_max))
+        resolution: 网格点数
+        """
+        self.bounds = bounds
+        self.res = resolution
+        x = np.linspace(bounds[0][0], bounds[0][1], resolution)
+        y = np.linspace(bounds[1][0], bounds[1][1], resolution)
+        self.xx, self.yy = np.meshgrid(x, y)
+        self.fig = plt.figure(figsize=(10, 8))
+        self.ax = self.fig.add_subplot(111, projection='3d')
+
+    def update(self, value_func: Callable[[np.ndarray], float], step: int):
+        """
+        value_func: 接受一个形状 (2,) 的状态数组，返回标量价值
+        step: 当前训练步数/episode数
+        """
+        zz = np.zeros_like(self.xx)
+        for i in range(self.res):
+            for j in range(self.res):
+                state = np.array([self.xx[i, j], self.yy[i, j]])
+                zz[i, j] = value_func(state)
+        self.ax.clear()
+        self.ax.plot_surface(self.xx, self.yy, zz, cmap='coolwarm', alpha=0.8)
+        self.ax.set_xlabel('State dim 1', fontsize=10)
+        self.ax.set_ylabel('State dim 2', fontsize=10)
+        self.ax.set_zlabel('Value', fontsize=10)
+        self.ax.set_title(f'Value Function Surface at Step {step}')
+        plt.pause(0.001)
+
+    def save(self, filepath: str):
+        """保存当前图表（自动创建目录）"""
+        dirname = os.path.dirname(filepath)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
+        self.fig.savefig(filepath, dpi=150)
+        print(f"价值曲面图已保存到: {filepath}")
+
+    def close(self):
+        plt.close(self.fig)
+
+
+# ========== 以下是原有代码（TrainingVisualizer, QTableVisualizer, PerformanceAnalyzer）保持不变 ==========
 
 class TrainingVisualizer:
     """训练可视化器"""


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 

## 修改的详细描述
1. **新增 `LivePlot` 类**：支持实时更新多条训练曲线（如奖励、损失、滑动平均），可在训练过程中动态观察指标变化。  
2. **新增 `PolicyHeatmap` 类**：针对离散动作空间，实时展示策略网络输出的动作概率分布热力图，帮助理解智能体的决策偏好。  
3. **新增 `ValueSurface` 类**：为二维连续状态空间绘制 3D 价值函数曲面图，直观展示价值函数的形状。  
4. **扩展 `ExperimentTracker`**：添加 `save_figure()` 方法，在实验过程中自动将 matplotlib 图表保存到实验子目录（`experiments/<exp_id>/figures/`）。  
5. **新增 `VisualizationManager`**：提供统一的可视化管理接口，简化训练脚本中的集成工作。  
6. **添加示例演示脚本 `demo_visualization.py`**：演示如何使用新可视化工具生成实时曲线和热力图，并保存为图片。

## 经过了什么样的测试？
1. **操作系统**：Windows 11  
2. **Python 版本**：3.10  
3. **基础校验**：  
   - 运行 `demo_visualization.py`，成功弹出实时曲线窗口和热力图窗口。  
   - 生成的 `demo_live_plot.png` 和 `demo_heatmap.png` 图片内容正确（曲线具有上升趋势，热力图概率归一化）。  
   - `ExperimentTracker.save_figure()` 方法能够正确创建目录并保存图表。  
   

## 运行效果（动图、视频、图片、链接等）
策略热力图
<img width="802" height="367" alt="屏幕截图 2026-06-01 173331" src="https://github.com/user-attachments/assets/7d12e3b5-19d9-4de5-9503-491ccc520478" />
实时训练曲线
<img width="994" height="568" alt="屏幕截图 2026-06-01 173324" src="https://github.com/user-attachments/assets/f9f52c8f-1216-48d4-9bc9-5be024e51fc4" />
