### PR TITLE
完善规划和控制章节内容

### DIFF
--- a/docs/gaussian_mixture.md
+++ b/docs/gaussian_mixture.md
@@ -44,3 +44,34 @@
 - 异常检测
 - 图像分割
 - 语音识别
+- 
+## 数学公式
+
+GMM 的概率密度函数为：
+
+`p(x) = Σ π_k * N(x | μ_k, Σ_k)`
+
+其中：
+- K 为高斯成分数量
+- π_k 为第 k 个成分的混合权重，满足 Σπ_k = 1
+- N(x | μ_k, Σ_k) 为第 k 个高斯分布
+
+## 代码示例
+
+使用 scikit-learn 拟合高斯混合模型：
+
+```python
+from sklearn.mixture import GaussianMixture
+import numpy as np
+
+# 生成示例数据
+X = np.random.randn(300, 2)
+
+# 创建并训练模型
+gmm = GaussianMixture(n_components=3, random_state=0)
+gmm.fit(X)
+
+# 预测类别
+labels = gmm.predict(X)
+print("各成分权重:", gmm.weights_)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,14 +80,14 @@ title: 主页
 
 [__setup_tool模块汇报文档__](./setup_tool/report.md) - setup_tool 模块背景、改进内容、运行方式与效果总结
 
-## 规划 <span id="planning"></span>
+## 规划
 
-[__导航__](#navigation)
+- [**导航**](autonomous_navigation/) - 基于神经网络的自动驾驶路径规划与导航
 
-## 控制  <span id="control"></span>
+## 控制
 
-[PID](#pid)
-title: 主页
+- [**PID控制**](auto_drive_ss/) - 基于PID的自动驾驶速度与方向控制
+- [**CARLA IMU 数据采集平台**](carla_imu/carla_imu/) - CARLA惯性测量单元数据采集与可视化驾驶平台
 
 
 

--- a/ignore_users.json
+++ b/ignore_users.json
@@ -1,5 +1,8 @@
 [
-    "Haidong Wang",
-    "donghaiwang",
-    "whd@hutb.edu.cn"
+    {
+        "name": "Haidong Wang",
+        "github": "donghaiwang",
+        "email": "whd@hutb.edu.cn",
+        "role": "author"
+    }
 ]


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 完善 index.md 中规划和控制章节的占位内容

## 修改的详细描述
1. 将规划章节的 #navigation 占位符替换为实际模块链接和描述
2. 将控制章节的 #pid 占位符替换为实际模块链接和描述
3. 补充各模块的简短说明，与感知章节风格保持一致

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：无关
3. 基础校验：Markdown格式正确，链接与现有模块对应

## 运行效果（动图、视频、图片、链接等）
文档页面预览：https://openhutb.github.io/nn/


