### PR TITLE
人形机器人手臂摆动仿真

### DIFF
--- a/src/mujoco_human/main.py
+++ b/src/mujoco_human/main.py
@@ -2,31 +2,50 @@ import mujoco
 import mujoco.viewer
 import numpy as np
 
-# 直接调用 MuJoCo 官方自带的 humanoid 模型，绝对正确
+# 加载模型
 model = mujoco.MjModel.from_xml_path("humanoid.xml")
 data = mujoco.MjData(model)
+nu = model.nu
+print(f"模型控制维度 nu = {nu}")
 
-# 用模型自带的关键帧初始化，直接就是标准站立姿态！
-mujoco.mj_resetDataKeyframe(model, data, 0)
+# 初始抬高，防止陷地
+data.qpos[2] = 1.4
+mujoco.mj_forward(model, data)
 
-# PD控制参数（官方推荐的稳定参数）
-kp = 1000.0
-kd = 100.0
+# 增加地面摩擦力，防止滑倒
+for i in range(model.ngeom):
+    if "floor" in model.geom(i).name:
+        model.geom(i).friction = [10, 0.1, 0.1]
 
-# 启动仿真
+# PD控制参数
+kp = 100
+kd = 10
+
 with mujoco.viewer.launch_passive(model, data) as viewer:
-    # 调整视角，方便观察
-    viewer.cam.distance = 5
-    viewer.cam.elevation = -25
-    viewer.cam.lookat[:] = [0, 0, 1.2]
-
+    t = 0.0
     while viewer.is_running():
-        # 获取关节位置和速度
-        q = data.qpos[7: 7 + model.nu]
-        v = data.qvel[6: 6 + model.nu]
+        dt = model.opt.timestep
+        t += dt
 
-        # PD控制，目标就是初始的站立姿态
-        data.ctrl[:] = kp * (np.zeros_like(q) - q) - kd * v
+        # 手臂摆动幅度
+        swing = np.sin(t * 1.2) * 0.3
+        target = np.zeros(nu)
+
+        # 适配nu=16的手臂关节索引
+        if nu >= 16:
+            # 右肩+右肘（索引10、11、12）
+            target[10] = swing
+            target[11] = swing
+            target[12] = swing * 0.4
+            # 左肩+左肘（索引13、14、15）
+            target[13] = -swing
+            target[14] = -swing
+            target[15] = -swing * 0.4
+
+        # 获取关节状态
+        q = data.qpos[7:7+nu]
+        v = data.qvel[6:6+nu]
+        data.ctrl[:] = kp * (target - q) - kd * v
 
         mujoco.mj_step(model, data)
         viewer.sync()


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 新增基于 MuJoCo 的人形机器人手臂摆动仿真项目，包含稳定站立控制与周期性手臂摆动功能。

## 修改的详细描述
1. 新增 `src/mujoco_human/main.py`，实现人形机器人基础稳定站立逻辑，通过提高地面摩擦力防止滑倒，设置初始姿态避免陷地。
2. 基于正弦信号规划手臂摆动轨迹，适配 `nu=16` 控制维度的关节索引，实现双臂反向周期性摆动。
3. 采用 PD 控制算法，保证动作平滑稳定，无倾倒、无抽搐，可直接运行复现。

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：3.0+
3. 基础校验：基础校验：代码可正常运行，仿真无报错；模型文件加载正常。

## 运行效果（动图、视频、图片、链接等）


<img width="805" height="554" alt="44444" src="https://github.com/user-attachments/assets/8499d3d0-9e24-42ac-b331-93d6f91f6417" />


