### PR TITLE
完善碰撞数据采集信息记录

### DIFF
--- a/src/drone_flight_sim/README.md
+++ b/src/drone_flight_sim/README.md
@@ -336,9 +336,8 @@ python collision_data_collector.py
 
 **CSV 数据格式：**
 ```
-filename,label,risk,min_depth,mean_depth,pos_x,pos_y
-collision_20260430_220825_0.0_0.0,0,safe,0.41,11811.93,0.0,0.0
-collision_20260430_221730_9.1_-10.1,1,danger,0.14,6190.47,9.1,-10.1
+filename,label,risk,min_depth,mean_depth,x,y,z,timestamp
+collision_xxx,0,safe,0.41,11811.93,0.0,0.0,-5.0,20260615_221530
 ```
 
 **下一步计划：**

--- a/src/drone_flight_sim/collision_data_collector.py
+++ b/src/drone_flight_sim/collision_data_collector.py
@@ -30,7 +30,7 @@ class CollisionDataCollector:
         # 如果 labels.csv 不存在，则创建并写入表头
         if not os.path.exists(self.labels_file):
             with open(self.labels_file, 'w') as f:
-                f.write("filename,label,risk,min_depth,mean_depth,x,y,z\n")
+                f.write("filename,label,risk,min_depth,mean_depth,x,y,z,timestamp\n")
 
         
         
@@ -81,9 +81,12 @@ class CollisionDataCollector:
             # 保存标签
             risk_name = "safe" if self.current_label == 0 else "danger"
             with open(self.labels_file, 'a') as f:
-                f.write(f"{filename},{self.current_label},{risk_name},"
+                    f.write(
+                        f"{filename},{self.current_label},{risk_name},"
                         f"{min_depth:.2f},{mean_depth:.2f},"
-                        f"{pos.x_val:.1f},{pos.y_val:.1f},{pos.z_val:.1f}\n")
+                        f"{pos.x_val:.1f},{pos.y_val:.1f},{pos.z_val:.1f},"
+                        f"{timestamp}\n"
+                    )
             self.sample_count += 1
             print(f"✅ 样本 {self.sample_count}: {filename} (深度:{min_depth:.1f}m)")
             return True


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->

修改概述: 
在碰撞数据采集模块中新增 timestamp 字段，用于记录样本采集的具体时间，完善数据集信息结构。

## 修改的详细描述
1. 在 collision_data_collector.py 的 labels.csv 表头中新增 timestamp 字段
2. 在数据保存时记录每个样本的采集时间（精确到秒）
3. 提升数据集可追溯性，便于后续训练与分析

## 经过了什么样的测试?
1. 操作系统：Windows 10/11
2. Python 版本：3.10.11
3. 基础校验：
   - 程序正常运行无报错
   - 可正常采集数据样本
   - CSV 文件正确写入 timestamp 字段
   - 数据格式与原有结构兼容

## 运行效果（动图、视频、图片、链接等）
- 成功生成带时间戳的碰撞数据集
- CSV 示例：
<img width="967" height="554" alt="屏幕截图 2026-06-15 223226" src="https://github.com/user-attachments/assets/f17cbe2a-8a94-4095-8
<img width="803" height="317" alt="屏幕截图 2026-06-15 223424" src="https://github.com/user-attachments/assets/876e4a3b-a641-405e-b7f7-bdc4627ad575" />
90c-f4de46c2784e" />


