### PR TITLE
优化自动碰撞数据采集统计信息，增加样本占比分析

### DIFF
--- a/src/drone_flight_sim/auto_collision_collector.py
+++ b/src/drone_flight_sim/auto_collision_collector.py
@@ -505,10 +505,21 @@ class AutoCollisionCollector:
 
     def get_stats(self):
         """获取采集统计"""
+        total = self.safe_samples + self.danger_samples
+
+        danger_ratio = 0
+        safe_ratio = 0
+
+        if total > 0:
+            danger_ratio = self.danger_samples / total * 100
+            safe_ratio = self.safe_samples / total * 100
+
         return {
             'safe': self.safe_samples,
             'danger': self.danger_samples,
-            'total': self.safe_samples + self.danger_samples
+            'total': total,
+            'safe_ratio': safe_ratio,
+            'danger_ratio': danger_ratio
         }
 
 
@@ -605,6 +616,8 @@ def main():
         print(f"   安全样本: {stats['safe']}")
         print(f"   危险样本: {stats['danger']}")
         print(f"   总计: {stats['total']}")
+        print(f"   安全样本占比: {stats['safe_ratio']:.1f}%")
+        print(f"   危险样本占比: {stats['danger_ratio']:.1f}%")
         print(f"   数据保存: {collector.labels_file}")
         print("=" * 50)
 


### PR DESCRIPTION
修改概述:

优化 auto_collision_collector.py 的数据统计功能，在采集完成后增加安全样本与危险样本占比信息输出，方便分析数据集分布情况，为后续模型训练提供参考。

## 修改的详细描述
1. 修改 get_stats() 方法，增加安全样本占比（safe_ratio）统计。
2. 修改 get_stats() 方法，增加危险样本占比（danger_ratio）统计。
3. 在采集完成后的统计输出中显示各类别样本占比信息，便于快速判断数据集是否均衡。

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：Python 3.10.11
3. 基础校验：
   - 成功运行 auto_collision_collector.py
   - 采集结束后正确输出安全样本数、危险样本数和总样本数
   - 正确显示安全样本占比与危险样本占比
   - 占比计算结果与样本数量对应关系正确

## 运行效果（动图、视频、图片、链接等）

运行自动采集程序后，统计信息示例：

<img width="1190" height="665" alt="屏幕截图 2026-06-15 232743" src="https://github.com/user-attachments/assets/44307ad0-6996-4560-ba38-3c99e919a81e" />
