### PR TITLE
修改无人机起始高度

### DIFF
--- a/src/drone_flight_sim/config.py
+++ b/src/drone_flight_sim/config.py
@@ -17,7 +17,7 @@ class FlightConfig:
 
     # ==================== 飞行参数 ====================
     # 起飞高度（负值表示向上，AirSim 中 Z 轴向下为正）
-    TAKEOFF_HEIGHT = -5
+    TAKEOFF_HEIGHT = -10
     # 飞行速度，单位：米/秒
     FLIGHT_VELOCITY = 4
     # 最大飞行时间，单位：秒，超过此时间将强制结束飞行


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 
调整无人机起飞高度，从5米改为10米，使飞行视野更开阔。
## 修改的详细描述
1. 修改文件：src/drone_flight_sim/config.py
2. 修改内容：TAKEOFF_HEIGHT = -10（原值为 -5）
3. 影响范围：无人机起飞后的悬停高度

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：3.10.11
3. 基础校验：

## 运行效果（动图、视频、图片、链接等）
<img width="1557" height="918" alt="屏幕截图 2026-06-16 032620" src="https://github.com/user-attachments/assets/7806e734-8a63-44cb-910e-944d7fdcbec9" />



