### PR TITLE
添加航点任务总览和实时进度显示

### DIFF
--- a/src/drone_flight_sim/main.py
+++ b/src/drone_flight_sim/main.py
@@ -42,16 +42,27 @@ def auto_flight_mode(drone):
 
    # 使用 FlightPath 中定义的三角形路径
     waypoints = FlightPath.triangle_path(size=15, height=-5)
+   
+   # ===== 新增：任务总览 =====
+    total = len(waypoints)
+    print(f"\n📋 任务总览:")
+    print(f"   总航点数: {total}")
+    for idx, (x, y, z) in enumerate(waypoints, 1):
+        print(f"   航点{idx}: ({x:.1f}, {y:.1f}, {z:.1f})")
+    print(f"{'=' * 40}\n")
 
     # 打印飞行路径信息
     FlightPath.print_path(waypoints)
 
     # ===== 执行飞行任务阶段 =====
     manual_takeover = False
+    completed = 0  # 新增：已完成的航点数量
 
     for i, (x, y, z) in enumerate(waypoints, 1):
+        remaining = total - i
         print(f"\n{'=' * 40}")
-        print(f"第 {i} 段飞行 -> 目标: ({x}, {y}, {z})")
+        print(f"📍 航点 {i}/{total} -> ({x}, {y}, {z})")
+        print(f"   剩余: {remaining} 个航点 | 已完成: {completed} 个")
         print(f"{'=' * 40}")
 
         # 飞向当前航点，速度 3 m/s
@@ -88,7 +99,8 @@ def auto_flight_mode(drone):
                     break
 
         # 到达航点后拍照
-        print(f"\n📷 航点 {i} 拍照...")
+        completed += 1  # 新增：完成计数
+        print(f"\n📷 航点 {i} 拍照... (进度: {completed}/{total})")
         drone.capture_image()
 
         time.sleep(1)


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 
在自动航点飞行模式中，添加任务总览和飞行进度显示
## 修改的详细描述
1. 飞行前显示任务总览（总航点数 + 每个航点坐标）
2. 飞行中显示剩余航点数和已完成航点数
3. 拍照时显示进度 (已完成/总数)

## 经过了什么样的测试?
1. 操作系统：
2. Python 版本：
3. 基础校验：

## 运行效果（动图、视频、图片、链接等）
<img width="1284" height="721" alt="屏幕截图 2026-06-16 203248" src="https://github.com/user-attachments/assets/7e9d0db1-432d-476f-87e1-67db2d6e42ed" />



