### PR TITLE
fix:修复YOLO+SORT跟踪图像显示条纹状伪影问题,并添加依赖模块sort

### DIFF
--- a/src/z_2d_tracking/2d_tracking_yolo_sort.py
+++ b/src/z_2d_tracking/2d_tracking_yolo_sort.py
@@ -1,0 +1,208 @@
+import carla
+
+import os
+import queue
+import random
+
+import cv2
+import numpy as np
+
+from sort.sort import Sort
+
+from utils.box_utils import draw_bounding_boxes
+from utils.projection import *
+from utils.world import *
+
+## Part 0: Object Detection model
+
+from what.models.detection.datasets.coco import COCO_CLASS_NAMES
+from what.models.detection.yolo.yolov4 import YOLOV4
+from what.models.detection.yolo.yolov4_tiny import YOLOV4_TINY
+
+from what.cli.model import *
+from what.utils.file import get_file
+
+# Check what_model_list for all supported models
+what_yolov4_model_list = what_model_list[4:6]
+
+
+index = 0 # YOLOv4 (原始版本)
+
+# Download the model first if not exists
+WHAT_YOLOV4_MODEL_FILE = what_yolov4_model_list[index][WHAT_MODEL_FILE_INDEX]
+WHAT_YOLOV4_MODEL_URL  = what_yolov4_model_list[index][WHAT_MODEL_URL_INDEX]
+WHAT_YOLOV4_MODEL_HASH = what_yolov4_model_list[index][WHAT_MODEL_HASH_INDEX]
+
+if not os.path.isfile(os.path.join(WHAT_MODEL_PATH, WHAT_YOLOV4_MODEL_FILE)):
+    get_file(WHAT_YOLOV4_MODEL_FILE,
+             WHAT_MODEL_PATH,
+             WHAT_YOLOV4_MODEL_URL,
+             WHAT_YOLOV4_MODEL_HASH)
+
+# Darknet
+model = YOLOV4(COCO_CLASS_NAMES, os.path.join(WHAT_MODEL_PATH, WHAT_YOLOV4_MODEL_FILE))
+# model = YOLOV4_TINY(COCO_CLASS_NAMES, os.path.join(WHAT_MODEL_PATH, WHAT_YOLOV4_MODEL_FILE))
+
+def camera_callback(image, rgb_image_queue):
+    # 必须使用 np.copy() 创建独立副本，避免 CARLA 共享缓冲区被覆盖
+    image_array = np.reshape(np.copy(image.raw_data), (image.height, image.width, 4))
+    rgb_image_queue.put(image_array)
+
+# Part 1
+client = carla.Client('localhost', 2000)
+world = client.get_world()
+
+# Set up the simulator in synchronous mode
+settings = world.get_settings()
+settings.synchronous_mode = True  # Enables synchronous mode
+settings.fixed_delta_seconds = 0.05
+world.apply_settings(settings)
+
+# Get the world spectator
+spectator = world.get_spectator()
+
+# Get the map spawn points
+spawn_points = world.get_map().get_spawn_points()
+
+# Spawn the ego vehicle
+bp_lib = world.get_blueprint_library()
+vehicle_bp = bp_lib.find('vehicle.lincoln.mkz_2020')
+vehicle = world.try_spawn_actor(vehicle_bp, random.choice(spawn_points))
+
+# Spawn the camera
+camera_bp = bp_lib.find('sensor.camera.rgb')
+# [Windows Only] Fixes https://github.com/carla-simulator/carla/issues/6085
+# CARLA 使用 64x64 的 tile 渲染，分辨率必须是 64 的倍数
+# 416 不是 64 的倍数，使用 448 (7×64)，然后裁剪到 416×416
+camera_bp.set_attribute('image_size_x', '448')
+camera_bp.set_attribute('image_size_y', '448')
+camera_bp.set_attribute('sensor_tick', '0.0')  # 传感器更新间隔
+camera_bp.set_attribute('gamma', '2.2')        # 伽马校正
+
+camera_init_trans = carla.Transform(carla.Location(x=1, z=2))
+camera = world.spawn_actor(camera_bp, camera_init_trans, attach_to=vehicle)
+
+# 目标分辨率（YOLOv4 输入尺寸）
+TARGET_WIDTH = 416
+TARGET_HEIGHT = 416
+
+# Create a queue to store and retrieve the sensor data
+image_queue = queue.Queue()
+camera.listen(lambda image: camera_callback(image, image_queue))
+
+# Clear existing NPCs
+clear_npc(world)
+clear_static_vehicle(world)
+
+# Part 2
+
+# Remember the edge pairs
+edges = [[0, 1], [1, 3], [3, 2], [2, 0], [0, 4], [4, 5],
+         [5, 1], [5, 7], [7, 6], [6, 4], [6, 2], [7, 3]]
+
+# Get the world to camera matrix
+world_2_camera = np.array(camera.get_transform().get_inverse_matrix())
+
+# Get the attributes from the camera
+image_w = camera_bp.get_attribute("image_size_x").as_int()
+image_h = camera_bp.get_attribute("image_size_y").as_int()
+fov = camera_bp.get_attribute("fov").as_float()
+
+# Calculate the camera projection matrix to project from 3D -> 2D
+K = build_projection_matrix(image_w, image_h, fov)
+K_b = build_projection_matrix(image_w, image_h, fov, is_behind_camera=True)
+
+# Spawn NPCs
+for i in range(50):
+    vehicle_bp = bp_lib.filter('vehicle')
+
+    # Exclude bicycle
+    car_bp = [bp for bp in vehicle_bp if int(
+        bp.get_attribute('number_of_wheels')) == 4]
+    npc = world.try_spawn_actor(random.choice(
+        car_bp), random.choice(spawn_points))
+
+    if npc:
+        npc.set_autopilot(True)
+
+vehicle.set_autopilot(True)
+
+mot_tracker = Sort( max_age=1, 
+                    min_hits=3,
+                    iou_threshold=0.3) #create instance of the SORT tracker
+
+# Main loop
+frame_count = 0
+while True:
+    try:
+        world.tick()
+
+        # Move the spectator to the top of the vehicle 
+        transform = carla.Transform(vehicle.get_transform().transform(carla.Location(x=-4,z=50)), carla.Rotation(yaw=-180, pitch=-90)) 
+        spectator.set_transform(transform) 
+
+        # Display RGB camera image
+        origin_image = image_queue.get()
+
+        
+        frame_count += 1
+
+        # 中心裁剪到目标分辨率（416×416）
+        height, width = origin_image.shape[:2]
+        start_x = (width - TARGET_WIDTH) // 2
+        start_y = (height - TARGET_HEIGHT) // 2
+        cropped_image = origin_image[start_y:start_y+TARGET_HEIGHT, start_x:start_x+TARGET_WIDTH]
+
+        # Image preprocessing (CARLA returns BGRA format)
+        image = cv2.cvtColor(cropped_image, cv2.COLOR_BGRA2RGB)
+
+        # Run inference
+        images, boxes, labels, probs = model.predict(image)
+
+        image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+
+        # Only draw 2: car, 5: bus, 7: truck
+        boxes = np.array([box for box, label in zip(boxes, labels) if label in [2, 5, 7]])
+        probs = np.array([prob for prob, label in zip(probs, labels) if label in [2, 5, 7]])
+        labels = np.array([2 for label in labels if label in [2, 5, 7]])
+
+        # convert [x1, y1, w, h] to [x1, y1, x2, y2]
+        if len(boxes) != 0:
+            sort_boxes = boxes.copy()
+
+            # (xc, yc, w, h) --> (x1, y1, x2, y2)
+            height, width, _ = image.shape
+
+            for box in sort_boxes:
+                box[0] *= width
+                box[1] *= height
+                box[2] *= width 
+                box[3] *= height
+
+                # From center to top left
+                box[0] -= box[2] / 2
+                box[1] -= box[3] / 2
+
+                # From width and height to x2 and y2
+                box[2] += box[0]
+                box[3] += box[1]
+
+            dets = np.concatenate((sort_boxes, probs.reshape((len(probs), -1))), axis=1)
+
+            # Update tracker
+            trackers = mot_tracker.update(dets)
+
+            # Draw bounding boxes onto the image
+            output = draw_bounding_boxes(image, trackers[:, 0:4], labels, model.class_names, trackers[:, 4]);
+
+        cv2.imshow('2D YOLOv4 SORT', output if 'output' in dir() else image)
+
+        # Quit if user presses 'q'
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    except KeyboardInterrupt as e:
+        break
+
+clear(world, camera)
+cv2.destroyAllWindows()

--- a/src/z_2d_tracking/sort/sort.py
+++ b/src/z_2d_tracking/sort/sort.py
@@ -1,0 +1,245 @@
+"""
+    SORT: A Simple, Online and Realtime Tracker
+    Copyright (C) 2016-2020 Alex Bewley alex@bewley.ai
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from __future__ import print_function
+
+import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
+
+from filterpy.kalman import KalmanFilter
+
+np.random.seed(0)
+
+def linear_assignment(cost_matrix):
+  try:
+    import lap
+    _, x, y = lap.lapjv(cost_matrix, extend_cost=True)
+    return np.array([[y[i],i] for i in x if i >= 0]) #
+  except ImportError:
+    from scipy.optimize import linear_sum_assignment
+    x, y = linear_sum_assignment(cost_matrix)
+    return np.array(list(zip(x, y)))
+
+
+def iou_batch(bb_test, bb_gt):
+  """
+  From SORT: Computes IOU between two bboxes in the form [x1,y1,x2,y2]
+  """
+  bb_gt = np.expand_dims(bb_gt, 0)
+  bb_test = np.expand_dims(bb_test, 1)
+  
+  xx1 = np.maximum(bb_test[..., 0], bb_gt[..., 0])
+  yy1 = np.maximum(bb_test[..., 1], bb_gt[..., 1])
+  xx2 = np.minimum(bb_test[..., 2], bb_gt[..., 2])
+  yy2 = np.minimum(bb_test[..., 3], bb_gt[..., 3])
+  w = np.maximum(0., xx2 - xx1)
+  h = np.maximum(0., yy2 - yy1)
+  wh = w * h
+  o = wh / ((bb_test[..., 2] - bb_test[..., 0]) * (bb_test[..., 3] - bb_test[..., 1])                                      
+    + (bb_gt[..., 2] - bb_gt[..., 0]) * (bb_gt[..., 3] - bb_gt[..., 1]) - wh)                                              
+  return(o)  
+
+
+def convert_bbox_to_z(bbox):
+  """
+  Takes a bounding box in the form [x1,y1,x2,y2] and returns z in the form
+    [x,y,s,r] where x,y is the centre of the box and s is the scale/area and r is
+    the aspect ratio
+  """
+  w = bbox[2] - bbox[0]
+  h = bbox[3] - bbox[1]
+  x = bbox[0] + w/2.
+  y = bbox[1] + h/2.
+  s = w * h    #scale is just area
+  r = w / float(h)
+  return np.array([x, y, s, r]).reshape((4, 1))
+
+
+def convert_x_to_bbox(x,score=None):
+  """
+  Takes a bounding box in the centre form [x,y,s,r] and returns it in the form
+    [x1,y1,x2,y2] where x1,y1 is the top left and x2,y2 is the bottom right
+  """
+  w = np.sqrt(x[2] * x[3])
+  h = x[2] / w
+  if(score==None):
+    return np.array([x[0]-w/2.,x[1]-h/2.,x[0]+w/2.,x[1]+h/2.]).reshape((1,4))
+  else:
+    return np.array([x[0]-w/2.,x[1]-h/2.,x[0]+w/2.,x[1]+h/2.,score]).reshape((1,5))
+
+
+class KalmanBoxTracker(object):
+  """
+  This class represents the internal state of individual tracked objects observed as bbox.
+  """
+  count = 0
+  def __init__(self,bbox):
+    """
+    Initialises a tracker using initial bounding box.
+    """
+    #define constant velocity model
+    self.kf = KalmanFilter(dim_x=7, dim_z=4) 
+    self.kf.F = np.array([[1,0,0,0,1,0,0],[0,1,0,0,0,1,0],[0,0,1,0,0,0,1],[0,0,0,1,0,0,0],  [0,0,0,0,1,0,0],[0,0,0,0,0,1,0],[0,0,0,0,0,0,1]])
+    self.kf.H = np.array([[1,0,0,0,0,0,0],[0,1,0,0,0,0,0],[0,0,1,0,0,0,0],[0,0,0,1,0,0,0]])
+
+    self.kf.R[2:,2:] *= 10.
+    self.kf.P[4:,4:] *= 1000. #give high uncertainty to the unobservable initial velocities
+    self.kf.P *= 10.
+    self.kf.Q[-1,-1] *= 0.01
+    self.kf.Q[4:,4:] *= 0.01
+
+    self.kf.x[:4] = convert_bbox_to_z(bbox)
+    self.time_since_update = 0
+    self.id = KalmanBoxTracker.count
+    KalmanBoxTracker.count += 1
+    self.history = []
+    self.hits = 0
+    self.hit_streak = 0
+    self.age = 0
+
+  def update(self,bbox):
+    """
+    Updates the state vector with observed bbox.
+    """
+    self.time_since_update = 0
+    self.history = []
+    self.hits += 1
+    self.hit_streak += 1
+    self.kf.update(convert_bbox_to_z(bbox))
+
+  def predict(self):
+    """
+    Advances the state vector and returns the predicted bounding box estimate.
+    """
+    if((self.kf.x[6]+self.kf.x[2])<=0):
+      self.kf.x[6] *= 0.0
+    self.kf.predict()
+    self.age += 1
+    if(self.time_since_update>0):
+      self.hit_streak = 0
+    self.time_since_update += 1
+    self.history.append(convert_x_to_bbox(self.kf.x))
+    return self.history[-1]
+
+  def get_state(self):
+    """
+    Returns the current bounding box estimate.
+    """
+    return convert_x_to_bbox(self.kf.x)
+
+
+def associate_detections_to_trackers(detections,trackers,iou_threshold = 0.3):
+  """
+  Assigns detections to tracked object (both represented as bounding boxes)
+
+  Returns 3 lists of matches, unmatched_detections and unmatched_trackers
+  """
+  if(len(trackers)==0):
+    return np.empty((0,2),dtype=int), np.arange(len(detections)), np.empty((0,5),dtype=int)
+
+  iou_matrix = iou_batch(detections, trackers)
+
+  if min(iou_matrix.shape) > 0:
+    a = (iou_matrix > iou_threshold).astype(np.int32)
+    if a.sum(1).max() == 1 and a.sum(0).max() == 1:
+        matched_indices = np.stack(np.where(a), axis=1)
+    else:
+      matched_indices = linear_assignment(-iou_matrix)
+  else:
+    matched_indices = np.empty(shape=(0,2))
+
+  unmatched_detections = []
+  for d, det in enumerate(detections):
+    if(d not in matched_indices[:,0]):
+      unmatched_detections.append(d)
+  unmatched_trackers = []
+  for t, trk in enumerate(trackers):
+    if(t not in matched_indices[:,1]):
+      unmatched_trackers.append(t)
+
+  #filter out matched with low IOU
+  matches = []
+  for m in matched_indices:
+    if(iou_matrix[m[0], m[1]]<iou_threshold):
+      unmatched_detections.append(m[0])
+      unmatched_trackers.append(m[1])
+    else:
+      matches.append(m.reshape(1,2))
+  if(len(matches)==0):
+    matches = np.empty((0,2),dtype=int)
+  else:
+    matches = np.concatenate(matches,axis=0)
+
+  return matches, np.array(unmatched_detections), np.array(unmatched_trackers)
+
+
+class Sort(object):
+  def __init__(self, max_age=1, min_hits=3, iou_threshold=0.3):
+    """
+    Sets key parameters for SORT
+    """
+    self.max_age = max_age
+    self.min_hits = min_hits
+    self.iou_threshold = iou_threshold
+    self.trackers = []
+    self.frame_count = 0
+
+  def update(self, dets=np.empty((0, 5))):
+    """
+    Params:
+      dets - a numpy array of detections in the format [[x1,y1,x2,y2,score],[x1,y1,x2,y2,score],...]
+    Requires: this method must be called once for each frame even with empty detections (use np.empty((0, 5)) for frames without detections).
+    Returns the a similar array, where the last column is the object ID.
+
+    NOTE: The number of objects returned may differ from the number of detections provided.
+    """
+    self.frame_count += 1
+    # get predicted locations from existing trackers.
+    trks = np.zeros((len(self.trackers), 5))
+    to_del = []
+    ret = []
+    for t, trk in enumerate(trks):
+      pos = self.trackers[t].predict()[0]
+      trk[:] = [pos[0], pos[1], pos[2], pos[3], 0]
+      if np.any(np.isnan(pos)):
+        to_del.append(t)
+    trks = np.ma.compress_rows(np.ma.masked_invalid(trks))
+    for t in reversed(to_del):
+      self.trackers.pop(t)
+    matched, unmatched_dets, unmatched_trks = associate_detections_to_trackers(dets,trks, self.iou_threshold)
+
+    # update matched trackers with assigned detections
+    for m in matched:
+      self.trackers[m[1]].update(dets[m[0], :])
+
+    # create and initialise new trackers for unmatched detections
+    for i in unmatched_dets:
+        trk = KalmanBoxTracker(dets[i,:])
+        self.trackers.append(trk)
+    i = len(self.trackers)
+    for trk in reversed(self.trackers):
+        d = trk.get_state()[0]
+        if (trk.time_since_update < 1) and (trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
+          ret.append(np.concatenate((d,[trk.id+1])).reshape(1,-1)) # +1 as MOT benchmark requires positive
+        i -= 1
+        # remove dead tracklet
+        if(trk.time_since_update > self.max_age):
+          self.trackers.pop(i)
+    if(len(ret)>0):
+      return np.concatenate(ret)
+    return np.empty((0,5))


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 
修复 YOLO+SORT 跟踪图像显示条纹状伪影问题

## 修改的详细描述
### 修复方案

1. 修改相机分辨率
将分辨率从 416×416 改为 448×448（7×64），确保是 64 的倍数

2. 添加中心裁剪逻辑
在推理前将图像中心裁剪到目标分辨率（416×416）

3. 修复缓冲区共享问题
使用 `np.copy()` 创建独立副本，避免 CARLA 共享缓冲区被覆盖




## 经过了什么样的测试?
1. 操作系统：
2. Python 版本：3.7.16
3. carla版本：0.9.14
4. 基础校验：

## 运行效果（动图、视频、图片、链接等）



https://github.com/user-attachments/assets/4e46a9f7-69b4-4b39-af35-0b7ff560ab15


