### PR TITLE
自动模式添加飞行任务计时器

### DIFF
--- a/src/drone_flight_sim/main.py
+++ b/src/drone_flight_sim/main.py
@@ -49,13 +49,20 @@ def auto_flight_mode(drone):
     # ===== 执行飞行任务阶段 =====
     manual_takeover = False
 
+    mission_start_time = time.time()
+
     for i, (x, y, z) in enumerate(waypoints, 1):
+        segment_start = time.time()
+
         print(f"\n{'=' * 40}")
         print(f"第 {i} 段飞行 -> 目标: ({x}, {y}, {z})")
         print(f"{'=' * 40}")
 
         # 飞向当前航点，速度 3 m/s
         success = drone.fly_to_position(x, y, z, velocity=3)
+
+        segment_elapsed = time.time() - segment_start
+        print(f"⏱ 本段耗时: {segment_elapsed:.1f}s")
 
         if not success:
             # 发生碰撞，尝试自动恢复
@@ -94,6 +101,9 @@ def auto_flight_mode(drone):
         time.sleep(1)
 
     # 降落阶段
+    total_elapsed = time.time() - mission_start_time
+    print_separator()
+    print(f"⏱ 总飞行时间: {total_elapsed:.1f}s")
     print_separator()
     if manual_takeover:
         print("⚠️  进入手动接管模式")


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 
自动模式添加飞行任务计时器
## 修改的详细描述
1. 在 auto_flight_mode 函数开始时记录任务开始时间
2. 每段航点飞行前记录段开始时间，飞行结束后显示本段耗时
3. 任务完成降落前显示总飞行时间

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：3.10.11
3. 基础校验：运行 python main.py 选择自动航点模式，正常显示每段耗时和总耗时

## 运行效果（动图、视频、图片、链接等）
<img width="1262" height="681" alt="屏幕截图 2026-06-17 030640" src="https://github.com/user-attachments/assets/af6505ba-506c-47ad-81da-9bef90b226eb" />



