### PR TITLE
feat: 键盘控制 H 键改为回到起飞点悬停

### DIFF
--- a/src/drone_flight_sim/keyboard_control.py
+++ b/src/drone_flight_sim/keyboard_control.py
@@ -235,9 +235,20 @@ class KeyboardController:
                 names = ['慢', '中', '快', '很快', '极速']
                 print(f"🎚️ 速度档位: {key_char} ({names[self.speed_level]}) - {SPEED_LEVELS[self.speed_level]} m/s")
                 return
-            # ===== 新增：H 键切换高度锁定 =====
+            # ===== H 键：回到起飞点悬停 =====
             if key_char == 'h' or key_char == 'H':
-                self._toggle_height_lock()
+                if self.home_position:
+                    print(f"\n🏠 回到起飞点悬停...")
+                    pos = self.drone.get_position()
+                    self.drone.client.moveToPositionAsync(
+                        self.home_position.x_val,
+                        self.home_position.y_val,
+                        pos.z_val,
+                        5
+                    )
+                    print(f"✅ 已回到起飞点 ({self.home_position.x_val:.1f}, {self.home_position.y_val:.1f})")
+                else:
+                    print("⚠️ 未设置返航点")
                 return
 
             # R 键：一键返航
@@ -504,7 +515,7 @@ def print_control_help():
   🎮 功能键:
      空格      : 悬停（停止移动）
      1-5       : 切换速度档位（慢/中/快/很快/极速）
-     H         : 切换高度锁定（保持当前高度）
+     H         : 回到起飞点悬停（保持当前高度）
      Y         : 显示实时遥测面板
      R         : 一键返航
      P         : 拍照


### PR DESCRIPTION
<!-- 感谢提交 pull request! -->
<!-- ⚠️⚠️ 不要删除该文件！这是 Pull Request 的模板 ⚠️⚠️ -->
<!-- 请阅读我们的贡献指南：https://github.com/OpenHUTB/.github/blob/master/CONTRIBUTING.md -->
修改概述: 
优化键盘控制模块，将 H 键功能从"高度锁定"改为"回到起飞点悬停"，方便无人机迷路时快速定位。
## 修改的详细描述
1. 将 H 键从原有的"高度锁定"功能改为"回到起飞点悬停"，无人机保持当前高度，仅回到起飞点的 X,Y 位置
2. 按下 H 键时显示"🏠 回到起飞点悬停..."，到达后显示"✅ 已回到起飞点 (x, y)"
3. 高度锁定相关的 _height_hold_loop、_start_height_hold、_stop_height_hold 方法保留

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：Python 3.10.11
3. 基础校验：无人机能正常回到起飞点，悬停状态正常，控制台输出提示信息正常

## 运行效果（动图、视频、图片、链接等）
<img width="1154" height="886" alt="屏幕截图 2026-06-18 010751" src="https://github.com/user-attachments/assets/69a1102e-914f-4109-9cac-7fbf0d47b9fb" />



