### PR TITLE
修复 keyboard_control.py 中重复获取按键字符的问题

### DIFF
--- a/src/drone_flight_sim/keyboard_control.py
+++ b/src/drone_flight_sim/keyboard_control.py
@@ -199,9 +199,11 @@ class KeyboardController:
                 self.drone.emergency_stop()
                 listener_running = False
                 return False
-            
-             # ===== 新增：Y 键显示遥测面板 =====
+
+            # 统一获取按键字符，避免重复 hasattr 调用
             key_char = key.char if hasattr(key, 'char') else None
+
+            # ===== Y 键显示遥测面板 =====
             if key_char == 'y' or key_char == 'Y':
                 self._show_telemetry_panel()
                 return
@@ -214,9 +216,6 @@ class KeyboardController:
                     self.drone.hover()
                     print("🛸 悬停")
                 return
-
-            # 获取按键字符
-            key_char = key.char if hasattr(key, 'char') else None
 
             # 拍照模式下的特殊按键
             if self.photo_mode:


### PR DESCRIPTION
修改概述: 修复 keyboard_control.py 中重复获取按键字符的问题

修改的详细描述:
将 on_press 中 key_char 的获取统一到方法开头，消除第二次重复的 hasattr 调用
经过的什么样的测试?

操作系统：Windows
Python 版本：3.10.11
基础校验：键盘控制模式按键功能正常

运行效果（动图、视频、图片、链接等） 
<img width="1237" height="456" alt="image" src="https://github.com/user-attachments/assets/e8a992d5-8474-44a6-a58f-cea6e42f1d56" />
