### PR TITLE
为自动数据采集模块增加命令行参数支持，提高实验可复现性（解决冲突后重新提交）

### DIFF
--- a/src/drone_flight_sim/auto_collision_collector.py
+++ b/src/drone_flight_sim/auto_collision_collector.py
@@ -15,7 +15,7 @@ import airsim
 import numpy as np
 import cv2
 from datetime import datetime
-
+import argparse
 
 class AutoCollisionCollector:
     """自动碰撞数据采集器"""
@@ -596,8 +596,14 @@ def main():
     mode = select_mode()
 
     # 设置参数
-    duration = 180  # 默认3分钟
-    target = 100    # 每类目标样本数
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=180)
+    parser.add_argument("--target", type=int, default=100)
+
+    args = parser.parse_args()
+
+    duration = args.duration
+    target = args.target
 
     try:
         duration_input = input(f"\n采集时长(秒) [默认{duration}]: ").strip()


### PR DESCRIPTION
修改概述:

为自动碰撞数据采集模块增加命令行参数支持，使采集过程可配置化，提高实验可复现性与工程化程度。

## 修改的详细描述
1. 引入 argparse 模块
2. 支持 --duration 参数控制采集时长
3. 支持 --target 参数控制目标样本数

## 经过了什么样的测试?
1. 操作系统：Windows 11
2. Python 版本：Python 3.10.11
3. 基础校验：
   - 成功使用默认参数运行
   - 成功使用自定义参数运行
   - 不影响原有功能

## 运行效果（动图、视频、图片、链接等）

运行示例：

```bash
python auto_collision_collector.py --duration 300 --target 200

